### PR TITLE
Plugin Upgrades

### DIFF
--- a/codegen-testcase-archetype/pom.xml
+++ b/codegen-testcase-archetype/pom.xml
@@ -37,7 +37,7 @@
             <plugin>
     	       <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-archetype-plugin</artifactId>
-               <version>2.0</version>
+               <version>2.4</version>
             </plugin>
         </plugins>
     </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -35,12 +35,12 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-site-plugin</artifactId>
-               <version>3.4</version>
+               <version>3.5</version>
                <dependencies>
                   <dependency>
                      <groupId>org.apache.maven.doxia</groupId>
                      <artifactId>doxia-module-markdown</artifactId>
-                     <version>1.6</version>
+                     <version>1.7</version>
                   </dependency>
                </dependencies>
                <configuration>
@@ -52,7 +52,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-eclipse-plugin</artifactId>
-               <version>2.8</version>
+               <version>2.10</version>
                <configuration>
                   <downloadSources>true</downloadSources>
                   <!-- <projectNameTemplate>castor3248-[artifactId]</projectNameTemplate> -->
@@ -61,7 +61,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>3.3</version>
+               <version>3.5.1</version>
                <configuration>
                   <source>1.7</source>
                   <target>1.7</target>
@@ -85,7 +85,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-source-plugin</artifactId>
-               <version>2.4</version>
+               <version>3.0.0</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
@@ -95,7 +95,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
-               <version>2.19</version>
+               <version>2.19.1</version>
                <configuration>
                   <printSummary>${surefire.print.summary}</printSummary>
                </configuration>
@@ -129,7 +129,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-failsafe-plugin</artifactId>
-               <version>2.19</version>
+               <version>2.19.1</version>
                <configuration>
                   <printSummary>${surefire.print.summary}</printSummary>
                </configuration>
@@ -137,12 +137,12 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-jxr-plugin</artifactId>
-               <version>2.2</version>
+               <version>2.5</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-pmd-plugin</artifactId>
-               <version>3.5</version>
+               <version>3.6</version>
             </plugin>
             <plugin>
                <groupId>org.codehaus.castor</groupId>
@@ -221,7 +221,7 @@
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>wagon-maven-plugin</artifactId>
-            <version>1.0-beta-2</version>
+            <version>1.0</version>
          </plugin>
       </plugins>
 
@@ -234,7 +234,7 @@
          <extension>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-webdav-jackrabbit</artifactId>
-            <version>2.0</version>
+            <version>2.9</version>
          </extension>
       </extensions>
 
@@ -567,13 +567,18 @@
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-project-info-reports-plugin</artifactId>
+            <version>2.9</version>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
             <version>2.5</version>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.18.1</version>
+            <version>2.19.1</version>
             <configuration>
                <excludes>
                   <exclude>org/castor/tools/log4j/TestCastorAppender.java</exclude>
@@ -609,7 +614,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-report-plugin</artifactId>
-            <version>2.18.1</version>
+            <version>2.19.1</version>
          </plugin>
 
          <plugin>
@@ -651,6 +656,11 @@
             <version>1.6</version>
          </plugin>
 
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>versions-maven-plugin</artifactId>
+            <version>2.2</version>
+         </plugin>
       </plugins>
    </reporting>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-assembly-plugin</artifactId>
-                  <version>2.5.3</version>
+                  <version>2.6</version>
                </plugin>
             </plugins>
          </build>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -8,7 +8,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.3.0</version>
+    <version>1.5</version>
   </skin>
     
   <bannerRight>


### PR DESCRIPTION
* General plugin updates to their latest versions.
* Maven Site Plugin 3.5 uses Doxia 1.7 and requires Fluido Skin 1.5.
* Added missing maven-project-info-reports-plugin declaration to avoid build warnings.
* Added the versions plugin, to make it easier to detect future opportunities.