### PR TITLE
Consistent maven-compiler-plugin for examples module

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,8 +22,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
                     <excludes>
                         <exclude implementation="java.lang.String">codegen/InvoiceTest*</exclude>
                     </excludes>


### PR DESCRIPTION
Examples do not need a specific or lower java compliance setting than the whole project.
The examples module declares the `maven-compiler-plugin` to add an `excludes`; no need to declare `source` and `target`.