### PR TITLE
Truly temp

### DIFF
--- a/codegen/src/test/java/org/exolab/castor/builder/appInfo/AppInfoProcessingTest.java
+++ b/codegen/src/test/java/org/exolab/castor/builder/appInfo/AppInfoProcessingTest.java
@@ -47,7 +47,7 @@ public class AppInfoProcessingTest extends TestCase {
     public final void setUp() throws Exception {
         super.setUp();
         _generator = new ExtendedSourceGenerator();
-        _generator.setDestDir("./codegen/target/generated-sources/castor");
+        _generator.setDestDir("./target/codegen/generated-sources/castor");
         _generator.setSuppressNonFatalWarnings(true);
 
         // uncomment to use Velocity for code generation

--- a/codegen/src/test/java/org/exolab/castor/builder/cdr/CdrFileGenerationTest.java
+++ b/codegen/src/test/java/org/exolab/castor/builder/cdr/CdrFileGenerationTest.java
@@ -38,7 +38,7 @@ public class CdrFileGenerationTest extends TestCase {
     private SourceGenerator _generator;
     private String _xmlSchema;
     private String _cdrDirectoryName;
-    private String _destDir = "./codegen/src/test/java";
+    private String _destDir = "./target/codegen/src/test/java";
 
     public final void setUp() throws Exception {
         super.setUp();

--- a/codegen/src/test/java/xml/annotation/TestSourceGenerator.java
+++ b/codegen/src/test/java/xml/annotation/TestSourceGenerator.java
@@ -11,7 +11,7 @@ public class TestSourceGenerator extends TestCase {
         SourceGenerator generator = new SourceGenerator();
         String xmlSchema = getClass().getResource("test.xsd").toExternalForm();
         InputSource inputSource = new InputSource(xmlSchema);
-        generator.setDestDir("./codegen/src/test/java");
+        generator.setDestDir("./target/codegen/src/test/java");
         generator.setSuppressNonFatalWarnings(true);
         
         // uncomment to have JDO-specific class descriptors created 

--- a/codegen/src/test/java/xml/srcgen/solrj/TestSourceGenerator.java
+++ b/codegen/src/test/java/xml/srcgen/solrj/TestSourceGenerator.java
@@ -11,10 +11,10 @@ public class TestSourceGenerator extends TestCase {
         SourceGenerator generator = new SourceGenerator();
         String xmlSchema = getClass().getResource("test.xsd").toExternalForm();
         InputSource inputSource = new InputSource(xmlSchema);
-        generator.setDestDir("./codegen/src/test/java");
+        generator.setDestDir("./target/codegen/src/test/java");
 
         // uncomment to set a resource destination directory
-//        generator.setResourceDestinationDirectory("./codegen/src/test/resources");
+//        generator.setResourceDestinationDirectory("./target/codegen/src/test/resources");
 
         generator.setSuppressNonFatalWarnings(true);
         

--- a/codegen/src/test/java/xml/srcgen/template/TestSourceGenerator.java
+++ b/codegen/src/test/java/xml/srcgen/template/TestSourceGenerator.java
@@ -11,10 +11,10 @@ public class TestSourceGenerator extends TestCase {
         SourceGenerator generator = new SourceGenerator();
         String xmlSchema = getClass().getResource("test.xsd").toExternalForm();
         InputSource inputSource = new InputSource(xmlSchema);
-        generator.setDestDir("./codegen/src/test/java");
+        generator.setDestDir("./target/codegen/src/test/java");
 
         // uncomment to set a resource destination directory
-//        generator.setResourceDestinationDirectory("./codegen/src/test/resources");
+//        generator.setResourceDestinationDirectory("./target/codegen/src/test/resources");
 
         generator.setSuppressNonFatalWarnings(true);
         

--- a/codegen/src/test/resources/log4j.xml
+++ b/codegen/src/test/resources/log4j.xml
@@ -10,7 +10,7 @@
     </appender>
 
     <appender name="file" class="org.apache.log4j.RollingFileAppender">
-        <param name="File" value="castor-codegen-log.txt"/>
+        <param name="File" value="target/castor-codegen-log.txt"/>
         <param name="MaxFileSize" value="2MB"/>
         <param name="MaxBackupIndex" value="2"/>
         <layout class="org.apache.log4j.PatternLayout">


### PR DESCRIPTION
When building, some files were being created that were not under the module's respective `target` directory.  This confused what is *source* vs *build results*.  As a result, I tweaked the unit tests to place these files under `target` so that `git` doesn't get confused as to whether they should be committed, and `mvn clean` will delete them properly.