### PR TITLE
Upgrade to Ant 1.9.6

### DIFF
--- a/anttask/pom.xml
+++ b/anttask/pom.xml
@@ -42,7 +42,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>ant</groupId>
+			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
 		</dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -348,9 +348,9 @@
          </dependency>
 
          <dependency>
-            <groupId>ant</groupId>
+            <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.6.5</version>
+            <version>1.9.6</version>
          </dependency>
 
          <dependency>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -174,12 +174,6 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
-        
-        <dependency>
-            <groupId>ant</groupId>
-            <artifactId>ant</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>edu.umd.cs.mtc</groupId>

--- a/xmlctf-framework/pom.xml
+++ b/xmlctf-framework/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
 
         <dependency>
-            <groupId>ant</groupId>
+            <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
         </dependency>
 


### PR DESCRIPTION
* The `groupId` for the `ant` dependency changed to `org.apache.ant`; the latest version is 1.9.6.
* The `xml` module had an unused, *test* dependency on `ant`, so it was removed.