### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/core/src/main/java/org/castor/core/nature/BaseNature.java
+++ b/core/src/main/java/org/castor/core/nature/BaseNature.java
@@ -91,10 +91,10 @@ public abstract class BaseNature implements Nature {
      * @return prefix + given key.
      */
     private String addPrefix(final String key) {
-        StringBuffer buf = new StringBuffer();
-        buf.append(getId());
-        buf.append(key);
-        return buf.toString();
+        return new StringBuilder()
+            .append(getId())
+            .append(key)
+            .toString();
     }
 
     /**

--- a/xml/src/main/java/org/castor/xml/JavaNamingImpl.java
+++ b/xml/src/main/java/org/castor/xml/JavaNamingImpl.java
@@ -380,11 +380,11 @@ public class JavaNamingImpl implements JavaNaming {
         if ((packageName == null) || (packageName.length() == 0)) {
             return fileName;
         }
-        StringBuffer result = new StringBuffer();
-        result.append(packageToPath(packageName));
-        result.append('/');
-        result.append(fileName);
-        return result.toString();
+        return new StringBuilder()
+            .append(packageToPath(packageName))
+            .append('/')
+            .append(fileName)
+            .toString();
     } // -- getQualifiedFileName
 
     /**

--- a/xml/src/main/java/org/castor/xml/JavaNamingNGImpl.java
+++ b/xml/src/main/java/org/castor/xml/JavaNamingNGImpl.java
@@ -379,11 +379,11 @@ public class JavaNamingNGImpl implements JavaNaming {
         if ((packageName == null) || (packageName.length() == 0)) {
             return fileName;
         }
-        StringBuffer result = new StringBuffer();
-        result.append(packageToPath(packageName));
-        result.append('/');
-        result.append(fileName);
-        return result.toString();
+        return new StringBuilder()
+            .append(packageToPath(packageName))
+            .append('/')
+            .append(fileName)
+            .toString();
     }
     
     /**

--- a/xml/src/main/java/org/exolab/castor/dsml/ImportDescriptor.java
+++ b/xml/src/main/java/org/exolab/castor/dsml/ImportDescriptor.java
@@ -273,9 +273,7 @@ public class ImportDescriptor extends HandlerBase implements Serializable {
         }
 
         String suffix(int index) {
-            StringBuffer name;
-
-            name = new StringBuffer(_names[index]);
+            StringBuilder name = new StringBuilder(_names[index]);
             for (++index; index < _names.length; ++index) {
                 name.append(',').append(_names[index]);
             }

--- a/xml/src/main/java/org/exolab/castor/mapping/loader/FieldDescriptorImpl.java
+++ b/xml/src/main/java/org/exolab/castor/mapping/loader/FieldDescriptorImpl.java
@@ -383,8 +383,12 @@ public class FieldDescriptorImpl implements FieldDescriptor {
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(getFieldName() + "(" + getFieldType().getName() + ")");
+        return new StringBuilder()
+            .append(getFieldName())
+            .append('(')
+            .append(getFieldType().getName())
+            .append(')')
+            .toString();
         // TODO[WG]: find a way to emit additional nature-specific information.
 //        try {
 //            Class natureClass = Class.forName("org.exolab.castor.jdo.engine.nature.FieldDescriptorJDONature");
@@ -396,7 +400,6 @@ public class FieldDescriptorImpl implements FieldDescriptor {
 //        } catch (ClassNotFoundException e) {
 //            // ignore
 //        }
-        return buffer.toString();
     }
 
 }

--- a/xml/src/main/java/org/exolab/castor/net/util/URIUtils.java
+++ b/xml/src/main/java/org/exolab/castor/net/util/URIUtils.java
@@ -51,6 +51,8 @@ import java.net.MalformedURLException;
 import java.util.Stack;
 import java.util.StringTokenizer;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * A utility class for URI handling
  *
@@ -256,12 +258,7 @@ public class URIUtils {
         }
         
         //-- rebuild URL
-        StringBuffer buffer = new StringBuffer(absoluteURL.length());
-        for (int i = 0; i < tokens.size(); i++) {
-            if (i > 0) buffer.append(HREF_PATH_SEP);
-            buffer.append(tokens.elementAt(i).toString());
-        }
-        return buffer.toString();
+        return StringUtils.join(tokens, HREF_PATH_SEP);
     } //-- normalize
     
     
@@ -357,19 +354,14 @@ public class URIUtils {
 
 	    if (filename == null) return FILE_PROTOCOL_PREFIX;
 	    int size = filename.length() + FILE_PROTOCOL_PREFIX.length();
-	    StringBuffer sb = new StringBuffer(size);
+	    StringBuilder sb = new StringBuilder(size);
 	    sb.append(FILE_PROTOCOL_PREFIX);
 	    char[] chars = filename.toCharArray();
-	    for (int i = 0; i < chars.length; i++) {
-	        char ch = chars[i];
-	        switch (ch) {
-	            case '\\':
-	                sb.append(HREF_PATH_SEP);
-	                break;
-	            default:
-	                sb.append(ch);
-	                break;
-
+	    for (char ch : chars) {
+	        if ('\\' == ch) {
+	            sb.append(HREF_PATH_SEP);
+	        } else {
+	            sb.append(ch);
 	        }
 	    }
 	    return sb.toString();

--- a/xml/src/main/java/org/exolab/castor/types/AnyNode.java
+++ b/xml/src/main/java/org/exolab/castor/types/AnyNode.java
@@ -551,7 +551,7 @@ public final class AnyNode implements java.io.Serializable {
     }
 
     private String privateToString() {
-        StringBuffer sb = new StringBuffer(4096);
+        StringBuilder sb = new StringBuilder(4096);
 
         if (_elements == null) {
             _elements = new Stack();
@@ -564,10 +564,10 @@ public final class AnyNode implements java.io.Serializable {
 
             if (this.getNodeType() == ELEMENT) {
                 //open the tag
-                sb.append("<");
+                sb.append('<');
                 String prefix = getNamespacePrefix();
                 if (prefix != null) {
-                    sb.append(prefix+":");
+                    sb.append(prefix).append(':');
                 }
                 prefix = null;
                 sb.append(getLocalName());
@@ -575,41 +575,44 @@ public final class AnyNode implements java.io.Serializable {
                 //append the attributes
                 AnyNode tempNode = this.getFirstAttribute();
                 while (tempNode != null) {
-                    sb.append(" ");
-                    sb.append(tempNode.getLocalName());
-                    sb.append("='"+tempNode.getStringValue()+"'");
+                    sb.append(' ')
+                        .append(tempNode.getLocalName())
+                        .append("='")
+                        .append(tempNode.getStringValue())
+                        .append('\'');
                     tempNode = tempNode.getNextSibling();
                 }
 
                 //append the namespaces
                 tempNode = this.getFirstNamespace();
                 while (tempNode != null) {
-                    sb.append(" ");
-                    sb.append(XMLNS_PREFIX);
+                    sb.append(' ')
+                        .append(XMLNS_PREFIX);
                     prefix = tempNode.getNamespacePrefix();
                     if (prefix != null && prefix.length() != 0) {
-                        sb.append(":"+prefix);
+                        sb.append(':').append(prefix);
                     }
-                    sb.append("='"+tempNode.getNamespaceURI()+"'");
+                    sb.append("='")
+                        .append(tempNode.getNamespaceURI())
+                        .append('\'');
                     tempNode = tempNode.getNextSibling();
                 }//namespaceNode
 
                 tempNode = this.getFirstChild();
                 if (tempNode != null) {
-                    sb.append(">");
+                    sb.append('>');
                     while (tempNode != null) {
                         sb.append(tempNode.privateToString());
                         tempNode = tempNode.getNextSibling();
                     }
                     //close the tag
-                    sb.append("</"+getLocalName()+">");
+                    sb.append("</").append(getLocalName()).append('>');
                 } else {
                     sb.append("/>");
                 }
             } else {
                 sb.append(this.getStringValue());
             }
-            return sb.toString();
         }
         return sb.toString();
     }//toString()

--- a/xml/src/main/java/org/exolab/castor/types/AnyNode.java
+++ b/xml/src/main/java/org/exolab/castor/types/AnyNode.java
@@ -669,9 +669,7 @@ public final class AnyNode implements java.io.Serializable {
             return;
         }
 
-        StringBuffer temp = new StringBuffer(node1.getStringValue());
-        temp.append(node2.getStringValue());
-        node1._value = temp.toString();
+        node1._value = node1.getStringValue() + node2.getStringValue();
         node2 = null;
     }
 

--- a/xml/src/main/java/org/exolab/castor/types/Century.java
+++ b/xml/src/main/java/org/exolab/castor/types/Century.java
@@ -113,15 +113,14 @@ public class Century extends TimePeriod {
      * @return a string representing this Century
      */
      public String toString() {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder(String.valueOf(this.getCentury()));
 
-        result.append(String.valueOf(this.getCentury()));
         if (result.length() == 1) {
             result.insert(0,0);
         }
 
         if (isNegative()) {
-            result.insert(0,"-");
+            result.insert(0,'-');
         }
         return result.toString();
     }//toString

--- a/xml/src/main/java/org/exolab/castor/types/Duration.java
+++ b/xml/src/main/java/org/exolab/castor/types/Duration.java
@@ -338,25 +338,22 @@ public class Duration implements java.io.Serializable {
             return "PT0S";
         }
 
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         if (_isNegative) {
             result.append('-');
         }
         result.append("P");
 
         if (_year != 0) {
-            result.append(_year);
-            result.append('Y');
+            result.append(_year).append('Y');
         }
 
         if (_month != 0) {
-            result.append(_month);
-            result.append('M');
+            result.append(_month).append('M');
         }
 
         if (_day != 0) {
-            result.append(_day);
-            result.append('D');
+            result.append(_day).append('D');
         }
 
         boolean isThereTime = _hour != 0 || _minute != 0 || _second != 0 || _millisecond != 0;
@@ -364,13 +361,11 @@ public class Duration implements java.io.Serializable {
             result.append('T');
 
             if (_hour != 0) {
-                result.append(_hour);
-                result.append('H');
+                result.append(_hour).append('H');
             }
 
             if (_minute != 0) {
-                result.append(_minute);
-                result.append('M');
+                result.append(_minute).append('M');
             }
 
             if (_second != 0 || _millisecond != 0) {

--- a/xml/src/main/java/org/exolab/castor/types/Duration.java
+++ b/xml/src/main/java/org/exolab/castor/types/Duration.java
@@ -342,7 +342,7 @@ public class Duration implements java.io.Serializable {
         if (_isNegative) {
             result.append('-');
         }
-        result.append("P");
+        result.append('P');
 
         if (_year != 0) {
             result.append(_year).append('Y');

--- a/xml/src/main/java/org/exolab/castor/types/Month.java
+++ b/xml/src/main/java/org/exolab/castor/types/Month.java
@@ -161,7 +161,7 @@ public class Month extends TimePeriod {
      */
      public String toString() {
 
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         result.append(this.getCentury());
         if (result.length() == 1)
             result.insert(0,0);

--- a/xml/src/main/java/org/exolab/castor/types/RecurringDuration.java
+++ b/xml/src/main/java/org/exolab/castor/types/RecurringDuration.java
@@ -393,31 +393,30 @@ public class RecurringDuration extends RecurringDurationBase{
      */
     private final String toPrivateString() {
 
-        StringBuffer result = new StringBuffer();
-        StringBuffer timeZone = null;
+        StringBuilder result = new StringBuilder();
 
         if (this.getCentury() == -1)
             result.append('-');
         else {
             if (this.getCentury()/10 == 0)
-            result.append(0);
+                result.append(0);
             result.append(this.getCentury());
 
-             if ((this.getYear()/10) == 0)
+            if ((this.getYear()/10) == 0)
                 result.append(0);
-             result.append(this.getYear());
+            result.append(this.getYear());
         }
         result.append('-');
         if (this.getMonth() == -1)
             result.append('-');
         else {
             if ((this.getMonth() / 10) == 0 )
-               result.append(0);
+                result.append(0);
             result.append(this.getMonth());
         }
         result.append('-');
         if (this.getDay() == -1)
-             result.append('-');
+            result.append('-');
         else {
             if ((this.getDay()/10) == 0 )
                 result.append(0);
@@ -425,7 +424,7 @@ public class RecurringDuration extends RecurringDurationBase{
         }
         // nowhere it is said in the specs that Time can be omitted
         // choose to always keep it
-        result.append("T");
+        result.append('T');
         if (this.getHour() == -1)
             result.append('-');
         else {
@@ -457,7 +456,7 @@ public class RecurringDuration extends RecurringDurationBase{
 
         // by default we choose to not concat the Z
         if (!isUTC()) {
-            timeZone = new StringBuffer();
+            StringBuilder timeZone = new StringBuilder();
             if ((this.getZoneHour()/10) == 0)
                 timeZone.append(0);
             timeZone.append(this.getZoneHour());
@@ -470,11 +469,11 @@ public class RecurringDuration extends RecurringDurationBase{
             if (isZoneNegative())
                timeZone.insert(0,'-');
             else timeZone.insert(0,'+');
-            result.append(timeZone.toString());
+            result.append(timeZone);
         }
 
-       if (isNegative())
-          result.insert(0,'-');
+        if (isNegative())
+            result.insert(0,'-');
 
         return result.toString();
 

--- a/xml/src/main/java/org/exolab/castor/types/TimeDuration.java
+++ b/xml/src/main/java/org/exolab/castor/types/TimeDuration.java
@@ -309,30 +309,25 @@ public class TimeDuration implements java.io.Serializable {
      *@return a string representing the time duration
      */
      public String toString() {
-        StringBuffer result = new StringBuffer();
-        result.append("P");
+        StringBuilder result = new StringBuilder();
+        result.append('P');
         if (_year != 0) {
-            result.append(_year);
-            result.append("Y");
+            result.append(_year).append('Y');
         }
         if (_month != 0) {
-           result.append(_month);
-           result.append("M");
+           result.append(_month).append('M');
         }
         if (_day !=0 ) {
-            result.append(_day);
-            result.append("D");
+            result.append(_day).append('D');
         }
         boolean isThereTime = ( (_hour != 0) || (_minute != 0) || (_second != 0) );
         if (isThereTime) {
-            result.append("T");
+            result.append('T');
             if (_hour !=0 ) {
-                result.append(_hour);
-                result.append("H");
+                result.append(_hour).append('H');
             }
             if (_minute !=0) {
-                result.append(_minute);
-                result.append("M");
+                result.append(_minute).append('M');
             }
              if (_second != 0) {
                     result.append(_second);

--- a/xml/src/main/java/org/exolab/castor/types/Year.java
+++ b/xml/src/main/java/org/exolab/castor/types/Year.java
@@ -160,7 +160,7 @@ public class Year extends TimePeriod {
      */
      public String toString() {
 
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         result.append(this.getCentury());
         if (result.length() == 1)
             result.insert(0,0);

--- a/xml/src/main/java/org/exolab/castor/util/ChangeLog2XML.java
+++ b/xml/src/main/java/org/exolab/castor/util/ChangeLog2XML.java
@@ -97,7 +97,7 @@ public class ChangeLog2XML {
         boolean checkForVersion = false;
         boolean inEntry = false;
         String prevLine = null;
-        StringBuffer buffer = null;
+        StringBuilder buffer = null;
         String details = null;
         Changelog changelog = new Changelog();
         Release release = null;
@@ -117,8 +117,7 @@ public class ChangeLog2XML {
                    continue;
                 }
               inEntry = true;
-              buffer = new StringBuffer();
-              buffer.append(prevLine.trim());
+              buffer = new StringBuilder(prevLine.trim());
             }
             
             //-- empty line is either end of entry or ignorable
@@ -176,8 +175,7 @@ public class ChangeLog2XML {
                     continue;
                 }
                 inEntry = true;
-                buffer = new StringBuffer();
-                buffer.append(line.trim());
+                buffer = new StringBuilder(line.trim());
             }
             else {
                 

--- a/xml/src/main/java/org/exolab/castor/util/NestedIOException.java
+++ b/xml/src/main/java/org/exolab/castor/util/NestedIOException.java
@@ -139,14 +139,14 @@ public class NestedIOException extends java.io.IOException {
      * @return the String representation of this Exception.
     **/
     public String toString() {
-        StringBuffer sb = new StringBuffer("NestedIOException: ");
+        StringBuilder sb = new StringBuilder("NestedIOException: ");
         if (getMessage() != null) {
             sb.append(getMessage());
         }
         if ((_exception != null) && (_exception.getMessage() != null)) {
-            sb.append(" { nested error: ");
-            sb.append(_exception.getMessage());
-            sb.append('}');
+            sb.append(" { nested error: ")
+                .append(_exception.getMessage())
+                .append('}');
         }
         return sb.toString();
     } //-- toString

--- a/xml/src/main/java/org/exolab/castor/util/Version.java
+++ b/xml/src/main/java/org/exolab/castor/util/Version.java
@@ -97,7 +97,7 @@ public final class Version {
      */
     public static String getBuildVersion() {
         
-        StringBuffer buffer = new StringBuffer(VERSION);
+        StringBuilder buffer = new StringBuilder(VERSION);
         String classname = Version.class.getName();
         String resource = "/" + classname.replace('.', '/') + ".class";
         
@@ -138,7 +138,8 @@ public final class Version {
                 SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
                 buffer.append(format.format(date));
             }
-            else buffer.append("0");
+            else
+                buffer.append('0');
             buffer.append(']');
         }
         return buffer.toString();

--- a/xml/src/main/java/org/exolab/castor/util/dialog/ConsoleDialog.java
+++ b/xml/src/main/java/org/exolab/castor/util/dialog/ConsoleDialog.java
@@ -196,7 +196,7 @@ public class ConsoleDialog implements Dialog {
      * @return each character separated by a pipe and in parenthesis
      */
     private String makeList(final String values) {
-        StringBuffer sb = new StringBuffer(values.length() * 2);
+        StringBuilder sb = new StringBuilder(values.length() * 2);
         sb.append('(');
         for (int i = 0; i < values.length(); i++) {
             sb.append(values.charAt(i)).append('|');
@@ -214,7 +214,7 @@ public class ConsoleDialog implements Dialog {
      * @return each character in single quotes, comma separated
      */
     private String listInput(final String values) {
-        StringBuffer sb = new StringBuffer(values.length() * 4);
+        StringBuilder sb = new StringBuilder(values.length() * 4);
         for (int i = 0; i < values.length(); i++) {
             sb.append('\'') .append(values.charAt(i)) .append("', ");
         }

--- a/xml/src/main/java/org/exolab/castor/xml/BaseSax2EventFromStaxProducer.java
+++ b/xml/src/main/java/org/exolab/castor/xml/BaseSax2EventFromStaxProducer.java
@@ -253,12 +253,8 @@ public abstract class BaseSax2EventFromStaxProducer implements
      * @return
      */
     boolean isIgnorableWhitespace(char[] chars, int start, int length) {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(chars, start, length);
-        String string = buffer.toString();
-        if (string.trim().length() == 0)
-            return true;
-        return false;
+        String string = new String(chars, start, length);
+        return string.trim().length() == 0;
     }
 
     /**

--- a/xml/src/main/java/org/exolab/castor/xml/FieldValidator.java
+++ b/xml/src/main/java/org/exolab/castor/xml/FieldValidator.java
@@ -203,7 +203,7 @@ public class FieldValidator extends Validator {
                     && context.getInternalContext().getLenientIdValidation()) {
                 return;
             }
-            StringBuffer buff = new StringBuffer();
+            StringBuilder buff = new StringBuilder();
             if (!ERROR_NAME.equals(_descriptor.getXMLName())) {
                 buff.append(MessageFormat.format(resourceBundle.getString("validatorField.error.required.field.whose"), 
                         new Object[] {_descriptor.getFieldName(), object.getClass().getName(), _descriptor.getXMLName()}));
@@ -297,7 +297,7 @@ public class FieldValidator extends Validator {
         // required then we need to report the error. Otherwise size == 0 and
         // field is not required, so no error.
         if (size < _minOccurs && (size != 0 || _descriptor.isRequired())) {
-            StringBuffer buff = new StringBuffer();
+            StringBuilder buff = new StringBuilder();
             if (!ERROR_NAME.equals(_descriptor.getXMLName())) {
                 buff.append(MessageFormat.format(resourceBundle.getString("validatorField.error.exception.min.occurs.whose"), 
                         new Object[] { _minOccurs, _descriptor.getFieldName(), object.getClass().getName(),
@@ -311,7 +311,7 @@ public class FieldValidator extends Validator {
 
         // Check maximum.
         if (_maxOccurs >= 0 && size > _maxOccurs) {
-            StringBuffer buff = new StringBuffer();
+            StringBuilder buff = new StringBuilder();
             if (!ERROR_NAME.equals(_descriptor.getXMLName())) {
                 buff.append(MessageFormat.format(resourceBundle.getString("validatorField.error.exception.max.occurs.whose"), 
                         new Object[] { _maxOccurs, _descriptor.getFieldName(), object.getClass().getName(), _descriptor.getXMLName()}));

--- a/xml/src/main/java/org/exolab/castor/xml/Marshaller.java
+++ b/xml/src/main/java/org/exolab/castor/xml/Marshaller.java
@@ -1652,11 +1652,7 @@ public class Marshaller extends MarshalFramework {
         if (nsPrefix != null) {
             int len = nsPrefix.length();
             if (len > 0) {
-                StringBuffer sb = new StringBuffer(len+name.length()+1);
-                sb.append(nsPrefix);
-                sb.append(':');
-                sb.append(name);
-                qName = sb.toString();
+                qName = nsPrefix + ':' + name;
             }
             else qName = name;
         }
@@ -2685,10 +2681,10 @@ public class Marshaller extends MarshalFramework {
                     enumeration = colHandler.elements(value);
                 }
                 if (enumeration.hasMoreElements()) {
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     for (int v = 0; enumeration.hasMoreElements(); v++) {
                         if (v > 0) sb.append(' ');
-                        sb.append(getObjectID(enumeration.nextElement()).toString());
+                        sb.append(getObjectID(enumeration.nextElement()));
                     }
                     value = sb;
                 }
@@ -2739,7 +2735,7 @@ public class Marshaller extends MarshalFramework {
             enumeration = colHandler.elements(value);
         }
         if (enumeration.hasMoreElements()) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (int v = 0; enumeration.hasMoreElements(); v++) {
                 if (v > 0) {
                     sb.append(' ');
@@ -2751,7 +2747,7 @@ public class Marshaller extends MarshalFramework {
                     collectionValue = encodeBinaryData(collectionValue, descriptor.getComponentType());
                 }
                 
-                sb.append(collectionValue.toString());
+                sb.append(collectionValue);
             }
             returnValue = sb;
         }

--- a/xml/src/main/java/org/exolab/castor/xml/Namespaces.java
+++ b/xml/src/main/java/org/exolab/castor/xml/Namespaces.java
@@ -348,11 +348,11 @@ public final class Namespaces {
          if (ns.prefix != null) {
             int len = ns.prefix.length();
             if (len > 0) {
-               StringBuffer buf = new StringBuffer(6 + len);
-               buf.append(XMLNS);
-               buf.append(':');
-               buf.append(ns.prefix);
-               attName = buf.toString();
+               attName = new StringBuilder(6 + len)
+                   .append(XMLNS)
+                   .append(':')
+                   .append(ns.prefix)
+                   .toString();
                atts.addAttribute(attName, CDATA, ns.uri);
             }
             // case with no prefix but a nsURI

--- a/xml/src/main/java/org/exolab/castor/xml/StartElementProcessor.java
+++ b/xml/src/main/java/org/exolab/castor/xml/StartElementProcessor.java
@@ -200,7 +200,6 @@ public class StartElementProcessor {
         // int pIdx = _stateInfo.size() - 2; //-- index of parentState
         UnmarshalState targetState = parentState;
         String path = "";
-        StringBuffer pathBuf = null;
         int count = 0;
         boolean isWrapper = false;
         XMLClassDescriptor oldClassDesc = classDesc;
@@ -287,12 +286,11 @@ public class StartElementProcessor {
                 // (CASTOR-1039)
                 // isWrapper = (isWrapper || hasFieldsAtLocation(name,
                 // classDesc));
-                StringBuffer tmpLocation = new StringBuffer();
+                StringBuilder tmpLocation = new StringBuilder();
                 if (count > 0) {
-                    tmpLocation.append(path + "/" + name);
-                } else {
-                    tmpLocation.append(name);
+                    tmpLocation.append(path).append('/');
                 }
+                tmpLocation.append(name);
                 isWrapper = (isWrapper || MarshalFramework.hasFieldsAtLocation(
                         tmpLocation.toString(), classDesc));
             } else if (descriptor != null) {
@@ -301,15 +299,8 @@ public class StartElementProcessor {
                     break; // -- found
                 descriptor = null; // -- not found, try again
             } else {
-                if (pathBuf == null)
-                    pathBuf = new StringBuffer();
-                else
-                    pathBuf.setLength(0);
-                pathBuf.append(path);
-                pathBuf.append('/');
-                pathBuf.append(name);
                 isWrapper = (isWrapper || MarshalFramework.hasFieldsAtLocation(
-                        pathBuf.toString(), classDesc));
+                        path + '/' + name, classDesc));
             }
 
             // -- Make sure there are more parent classes on stack
@@ -322,14 +313,7 @@ public class StartElementProcessor {
             if (count == 0)
                 path = targetState.getElementName();
             else {
-                if (pathBuf == null)
-                    pathBuf = new StringBuffer();
-                else
-                    pathBuf.setLength(0);
-                pathBuf.append(targetState.getElementName());
-                pathBuf.append('/');
-                pathBuf.append(path);
-                path = pathBuf.toString();
+                path = targetState.getElementName() + '/' + path;
             }
 
             // -- get

--- a/xml/src/main/java/org/exolab/castor/xml/UnmarshalHandler.java
+++ b/xml/src/main/java/org/exolab/castor/xml/UnmarshalHandler.java
@@ -1389,10 +1389,10 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
             String name      = descriptor.getXMLName();
             String namespace = descriptor.getNameSpaceURI();
             String path = descriptor.getLocationPath();
-            StringBuffer fullAttributePath = new StringBuffer();
+            StringBuilder fullAttributePath = new StringBuilder();
             
             if (StringUtils.isNotEmpty(path)) {
-                fullAttributePath.append(path + "/"); 
+                fullAttributePath.append(path).append('/');
             }
             
             fullAttributePath.append(name);
@@ -1476,17 +1476,11 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
                 //-- check for nested attribute...loop through
                 //-- stack and find correct descriptor
                 String path = state.getElementName();
-                StringBuffer pathBuf = null;
                 Integer parentStateIndex = _stateStack.getFirstParentStateIndex(); 
                 while (parentStateIndex >= 0) {
                    UnmarshalState targetState = _stateStack.peekAtState(parentStateIndex--);
                    if (targetState.isWrapper()) {
-                      //path = targetState.elementName + "/" + path;
-                      pathBuf = resetStringBuffer(pathBuf);
-                      pathBuf.append(targetState.getElementName());
-                      pathBuf.append('/');
-                      pathBuf.append(path);
-                      path = pathBuf.toString();
+                      path = targetState.getElementName() + '/' + path;
                       continue;
                    }
                    classDesc = targetState.getClassDescriptor();
@@ -1500,12 +1494,8 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
                       }
                    }
 
-                   pathBuf = resetStringBuffer(pathBuf);
-                   pathBuf.append(targetState.getElementName());
-                   pathBuf.append('/');
-                   pathBuf.append(path);
-                   path = pathBuf.toString();
-                   //path = targetState.elementName + "/" + path;
+                   path = targetState.getElementName() + '/' + path;
+
                    //-- reset descriptor to make sure we don't
                    //-- exit the loop with a reference to a 
                    //-- potentially incorrect one.
@@ -1537,22 +1527,6 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
 
     }
 
-	/**
-	 * Returns either the passed in StringBuffer and sets its length to 0, or if
-	 * the StringBuffer is null, an empty StringBuffer
-	 * 
-	 * @param buffer
-	 *            a StringBuffer, can be null
-	 * @return returns an empty StringBuffer
-	 */
-	private StringBuffer resetStringBuffer(StringBuffer buffer) {
-		if (buffer == null)
-		    return new StringBuffer();
-		
-		buffer.setLength(0);
-		return buffer;
-	}
-
     /**
      * Processes the given AttributeSet for wrapper elements.
      * 
@@ -1580,16 +1554,11 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
             //-- check for nested attribute...loop through
             //-- stack and find correct descriptor
             String path = state.getElementName();
-            StringBuffer pathBuf = null;
             UnmarshalState targetState = null;
             while (_stateStack.hasAnotherParentState()) {
                 targetState = _stateStack.removeParentState();
                 if (targetState.isWrapper()) {
-                    pathBuf = resetStringBuffer(pathBuf);
-                    pathBuf.append(targetState.getElementName());
-                    pathBuf.append('/');
-                    pathBuf.append(path);
-                    path = pathBuf.toString();
+                    path = targetState.getElementName() + '/' + path;
                     continue;
                 }
                 classDesc = targetState.getClassDescriptor();
@@ -1614,11 +1583,7 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
                     break;
                 }
                         
-                pathBuf = resetStringBuffer(pathBuf);
-                pathBuf.append(targetState.getElementName());
-                pathBuf.append('/');
-                pathBuf.append(path);
-                path = pathBuf.toString();
+                path = targetState.getElementName() + '/' + path;
                 
                 //-- reset descriptor to make sure we don't
                 //-- exit the loop with a reference to a 
@@ -2138,7 +2103,7 @@ implements ContentHandler, DocumentHandler, ErrorHandler {
      * @return true if the only whitespace characters were
      * found in the given StringBuffer
     **/
-    static boolean isWhitespace(StringBuffer sb) {
+    static boolean isWhitespace(CharSequence sb) {
         for (int i = 0; i < sb.length(); i++) {
             char ch = sb.charAt(i);
             switch (ch) {

--- a/xml/src/main/java/org/exolab/castor/xml/UnmarshalState.java
+++ b/xml/src/main/java/org/exolab/castor/xml/UnmarshalState.java
@@ -325,13 +325,12 @@ public class UnmarshalState {
 
     @Override
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append("UnmarshalState [" + _elementName + "("+ _type + ") ");
+        StringBuilder buffer = new StringBuilder(
+            "UnmarshalState [" + _elementName + '(' + _type + ") ");
         if (!StringUtils.isEmpty(_location)) {
             buffer.append("rooted at location=" + _location + ", ]");
         }
         return buffer.toString();
-        
     }
     
     

--- a/xml/src/main/java/org/exolab/castor/xml/ValidationException.java
+++ b/xml/src/main/java/org/exolab/castor/xml/ValidationException.java
@@ -216,7 +216,7 @@ public class ValidationException extends XMLException {
      * @return the String representation of this ValidationException.
      */
     public String toString() {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         if (getNext() != null) {
             int count = 1;
             for (ValidationException vx = this; vx != null; vx = vx.getNext()) {
@@ -239,7 +239,7 @@ public class ValidationException extends XMLException {
      * @param sb The StringBuffer to which we print information
      * @param vx The ValidationException for which we print information.
      */
-    private void dumpOneException(final StringBuffer sb, final ValidationException vx) {
+    private void dumpOneException(final StringBuilder sb, final ValidationException vx) {
         sb.append("ValidationException: ");
         String message = vx.getMessage();
         if (message != null) {
@@ -248,11 +248,11 @@ public class ValidationException extends XMLException {
         Location location = vx.getLocation();
         if (location != null) {
             sb.append(";\n   - location of error: ");
-            sb.append(location.toString());
+            sb.append(location);
         }
         Throwable t = vx.getCause();
         if (t != null) {
-            sb.append("\n");
+            sb.append('\n');
             sb.append(t.getMessage());
         }
     }

--- a/xml/src/main/java/org/exolab/castor/xml/XMLException.java
+++ b/xml/src/main/java/org/exolab/castor/xml/XMLException.java
@@ -146,8 +146,7 @@ public class XMLException extends CastorException {
      * @return the String representation of this Exception.
      */
     public String toString() {
-        StringBuffer buff = new StringBuffer();
-        buff.append(this.getClass().getName());
+        StringBuilder buff = new StringBuilder(this.getClass().getName());
         
         String msg = this.getMessage();
         if (msg != null) {
@@ -155,7 +154,7 @@ public class XMLException extends CastorException {
         }
         
         if (this._location != null) {
-            buff.append("{").append(this._location).append("}");
+            buff.append('{').append(this._location).append('}');
         }
         
         return buff.toString();

--- a/xml/src/main/java/org/exolab/castor/xml/XMLMappingLoader.java
+++ b/xml/src/main/java/org/exolab/castor/xml/XMLMappingLoader.java
@@ -194,10 +194,7 @@ public final class XMLMappingLoader extends AbstractMappingLoader {
                         }
                     } catch (ResolverException e) {
                         if (LOG.isDebugEnabled()) {
-                            String message =
-                                new StringBuffer().append("Ignoring exception: ").append(e)
-                                .append(" at resolving: ").append(classMapping.getName()).toString();
-                            LOG.debug(message);
+                            LOG.debug("Ignoring exception: " + e + " at resolving: " + classMapping.getName());
                         }
                     }
                 }

--- a/xml/src/main/java/org/exolab/castor/xml/handlers/CollectionFieldHandler.java
+++ b/xml/src/main/java/org/exolab/castor/xml/handlers/CollectionFieldHandler.java
@@ -159,13 +159,13 @@ public class CollectionFieldHandler extends XMLFieldHandler {
             return null;
         }
 
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         for (int i = 0; i < size; i++) {
             if (i > 0) {
                 result.append(' ');
             }
             Object obj = Array.get(temp, i);
-            result.append(obj.toString());
+            result.append(obj);
         }
         return result.toString();
     }

--- a/xml/src/main/java/org/exolab/castor/xml/handlers/DateFieldHandler.java
+++ b/xml/src/main/java/org/exolab/castor/xml/handlers/DateFieldHandler.java
@@ -391,9 +391,9 @@ public class DateFieldHandler extends XMLFieldHandler {
         cal.setTime(date);
         cal.setTimeZone(_timezone);
 
-        StringBuffer buffer = new StringBuffer(DEFAULT_DATE_LENGTH);
+        StringBuilder buffer = new StringBuilder(DEFAULT_DATE_LENGTH);
         if (cal.get(Calendar.ERA) == GregorianCalendar.BC) {
-            buffer.append("-");
+            buffer.append('-');
         }
 
         buffer.append(formatter.format(date));
@@ -404,9 +404,9 @@ public class DateFieldHandler extends XMLFieldHandler {
     /**
      * Format the time zone information (only) from the provided Calendar.
      * @param cal a calendar containing a time and time zone
-     * @param buffer the StringBuffer to which to format the time zone
+     * @param buffer the StringBuilder to which to format the time zone
      */
-    private static void formatTimeZone(final Calendar cal, final StringBuffer buffer) {
+    private static void formatTimeZone(final Calendar cal, final StringBuilder buffer) {
         int value = cal.get(Calendar.ZONE_OFFSET);
         int dstOffset = cal.get(Calendar.DST_OFFSET);
 

--- a/xml/src/main/java/org/exolab/castor/xml/location/FileLocation.java
+++ b/xml/src/main/java/org/exolab/castor/xml/location/FileLocation.java
@@ -160,7 +160,7 @@ public class FileLocation implements Location, java.io.Serializable {
      * @return the String representation of this FileLocation.
      */
     public String toString() {
-        final StringBuffer sb = new StringBuffer("File: ");
+        final StringBuilder sb = new StringBuilder("File: ");
 
         if (_filename != null) {
             sb.append(_filename);

--- a/xml/src/main/java/org/exolab/castor/xml/location/XPathLocation.java
+++ b/xml/src/main/java/org/exolab/castor/xml/location/XPathLocation.java
@@ -46,6 +46,8 @@ package org.exolab.castor.xml.location;
 
 import java.util.Vector;
 
+import org.apache.commons.lang3.StringUtils;
+
 
 /**
  * A very simple XPath location class for use with the ValidationException. This
@@ -60,7 +62,7 @@ public class XPathLocation implements Location, java.io.Serializable {
     private static final long serialVersionUID = 1L;
     
     /** Our XPath, built up one String at a time. */
-    private final Vector _path = new Vector();
+    private final Vector<String> _path = new Vector<>();
     
     /** If we have reached the logical end of XPath (i.e., an attribute), set to false. */
     private boolean _allowChildrenOrAtts = true;
@@ -106,13 +108,7 @@ public class XPathLocation implements Location, java.io.Serializable {
      * @return the String representation of this XPathLocation.
      */
     public String toString() {
-        StringBuffer buf = new StringBuffer("XPATH: ");
-
-        for (int i = 0; i < _path.size(); i++) {
-            buf.append('/');
-            buf.append((String)_path.elementAt(i));
-        }
-        return buf.toString();
+        return "XPATH: /" + StringUtils.join(_path, '/');
     }
 
 }

--- a/xml/src/main/java/org/exolab/castor/xml/util/AnyNode2SAX.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/AnyNode2SAX.java
@@ -200,11 +200,7 @@ public class AnyNode2SAX implements EventProducer {
             if (nsPrefix != null) {
                 int len = nsPrefix.length();
                 if (len > 0) {
-                    StringBuffer sb = new StringBuffer(len+name.length()+1);
-                    sb.append(nsPrefix);
-                    sb.append(':');
-                    sb.append(name);
-                    qName = sb.toString();
+                    qName = nsPrefix + ':' + name;
                 } else {
                     qName = name;
                 }

--- a/xml/src/main/java/org/exolab/castor/xml/util/AnyNode2SAX2.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/AnyNode2SAX2.java
@@ -218,11 +218,7 @@ public class AnyNode2SAX2 {
             if (nsPrefix != null) {
                 int len = nsPrefix.length();
                 if (len > 0) {
-                    StringBuffer sb = new StringBuffer(len + name.length() + 1);
-                    sb.append(nsPrefix);
-                    sb.append(':');
-                    sb.append(name);
-                    qName = sb.toString();
+                    qName = nsPrefix + ':' + name;
                 } else {
                     qName = name;
                 }

--- a/xml/src/main/java/org/exolab/castor/xml/util/DefaultNaming.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/DefaultNaming.java
@@ -157,7 +157,7 @@ public final class DefaultNaming extends AbstractXMLNaming implements XMLNaming 
         }
 
         //-- process each character
-        StringBuffer cbuff = new StringBuffer(name);
+        StringBuilder cbuff = new StringBuilder(name);
         cbuff.setCharAt(0, Character.toLowerCase(cbuff.charAt(0)));
 
         boolean ucPrev = false;

--- a/xml/src/main/java/org/exolab/castor/xml/util/XMLClassDescriptorImpl.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/XMLClassDescriptorImpl.java
@@ -970,7 +970,7 @@ public class XMLClassDescriptorImpl extends Validator implements XMLClassDescrip
                 // if all elements are mandatory, print the grammar that the choice 
                 // must match.
                 if ((!found) && (hasLocalDescs))  {
-                    StringBuffer buffer = new StringBuffer(40);
+                    StringBuilder buffer = new StringBuilder(40);
                     boolean existsOptionalElement = false;
                     buffer.append('(');
                     String sep = " | ";
@@ -985,14 +985,14 @@ public class XMLClassDescriptorImpl extends Validator implements XMLClassDescrip
                             existsOptionalElement = true;
                             break;
                         }
-                        buffer.append(sep);
-                        buffer.append(desc.getXMLName());
+                        buffer.append(sep)
+                            .append(desc.getXMLName());
                     }
                     buffer.append(')');
                     if (!existsOptionalElement) {
                         String err = "In the choice contained in <" + this.getXMLName()
                                      + ">, at least one of these elements must appear:\n"
-                                     + buffer.toString();
+                                     + buffer;
                         throw new ValidationException(err);
                     }
                 }

--- a/xml/src/main/java/org/exolab/castor/xml/util/XMLFieldDescriptorImpl.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/XMLFieldDescriptorImpl.java
@@ -748,13 +748,13 @@ public class XMLFieldDescriptorImpl extends FieldDescriptorImpl implements XMLFi
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer(32);
-        buffer.append("XMLFieldDesciptor: ");
-        buffer.append(getFieldName());
-        buffer.append(" AS ");
-        buffer.append(_xmlName);
+        StringBuilder buffer = new StringBuilder(32)
+            .append("XMLFieldDesciptor: ")
+            .append(getFieldName())
+            .append(" AS ")
+            .append(_xmlName);
         if (getNameSpaceURI() != null) {
-            buffer.append("{" + getNameSpaceURI() + "}");
+            buffer.append('{').append(getNameSpaceURI()).append('}');
         }
         return buffer.toString();
     }

--- a/xml/src/main/java/org/exolab/castor/xml/util/resolvers/ByDescriptorClass.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/resolvers/ByDescriptorClass.java
@@ -62,7 +62,7 @@ public class ByDescriptorClass extends AbstractResolverClassCommand {
             return results;
         }
 
-        StringBuffer descriptorClassName = new StringBuffer(className);
+        StringBuilder descriptorClassName = new StringBuilder(className);
         descriptorClassName.append(XMLConstants.DESCRIPTOR_SUFFIX);
         Class descriptorClass = ResolveHelpers.loadClass(
                 classLoader, descriptorClassName.toString());

--- a/xml/src/main/java/org/exolab/castor/xml/util/resolvers/ResolveHelpers.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/resolvers/ResolveHelpers.java
@@ -46,15 +46,11 @@ public final class ResolveHelpers {
      * @return The qualified file path.
      */
     public static String getQualifiedFileName(String fileName, String packageName) {
-        if (packageName == null || packageName.length() == 0) {
+        if (packageName == null || packageName.isEmpty()) {
             return fileName;
         }
         
-        StringBuffer result = new StringBuffer();
-        result.append(packageName.replace('.', '/'));
-        result.append('/');
-        result.append(fileName);
-        return result.toString();
+        return packageName.replace('.', '/') + '/' + fileName;
     } //-- getQualifiedFileName
 
     /**

--- a/xml/src/main/java/org/exolab/castor/xml/validators/PatternValidator.java
+++ b/xml/src/main/java/org/exolab/castor/xml/validators/PatternValidator.java
@@ -201,17 +201,17 @@ public abstract class PatternValidator {
         }
 
         // If we get here, all patterns failed.
-        StringBuffer buff = new StringBuffer("'" + str + "'");
+        StringBuilder buff = new StringBuilder("'" + str + "'");
         if (_patterns.size() == 1) {
             buff.append(MessageFormat.format(resourceBundle
                     .getString("patternValidator.error.pattern.not.match"),
                     new Object[] { _patterns.getFirst() }));
         } else {
-            StringBuffer patterns = new StringBuffer();
+            StringBuilder patterns = new StringBuilder();
             for (String pattern : _patterns) {
-                patterns.append("\"");
+                patterns.append('\"');
                 patterns.append(pattern);
-                patterns.append("\"");
+                patterns.append('\"');
             }
             
             buff.append(MessageFormat.format(resourceBundle

--- a/xml/src/test/java/org/exolab/castor/xml/Sax2EventFromStaxProducerTest.java
+++ b/xml/src/test/java/org/exolab/castor/xml/Sax2EventFromStaxProducerTest.java
@@ -376,12 +376,12 @@ public class Sax2EventFromStaxProducerTest extends TestCase {
 	public void testCharactersBuffer() throws XMLStreamException,
 			FactoryConfigurationError, SAXException, IOException {
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<Person>"
 				+ "<first-name> ");
 		
 		for (int i = 0; i < 1028; i++)
-			buffer.append("realyLongName" + i);
+			buffer.append("realyLongName").append(i);
 		
 		buffer.append("</first-name></Person>");
 

--- a/xml/src/test/java/org/exolab/castor/xml/Sax2MethodRecorder.java
+++ b/xml/src/test/java/org/exolab/castor/xml/Sax2MethodRecorder.java
@@ -99,11 +99,10 @@ public class Sax2MethodRecorder implements ContentHandler {
 
         if (charactersBuffer != null) {
             LOG.debug(" second characters event");
-            charactersBuffer.append(ch, start, length);
         } else {
             charactersBuffer = new StringBuffer(length);
-            charactersBuffer.append(ch, start, length);
         }
+        charactersBuffer.append(ch, start, length);
     }
 
     /**
@@ -130,9 +129,7 @@ public class Sax2MethodRecorder implements ContentHandler {
         try {
             String string = new String(charactersBuffer);
 
-            char[] chars;
-            chars = new char[charactersBuffer.length()];
-            chars = string.toCharArray();
+            char[] chars = string.toCharArray();
 
             contentMock.characters(EasyMock.aryEq(chars), EasyMock.eq(0),
                     EasyMock.eq(charactersBuffer.length()));
@@ -161,14 +158,9 @@ public class Sax2MethodRecorder implements ContentHandler {
             throws SAXException {
         LOG.debug("< ignorableWhitespace >");
 
-        StringBuffer buffer = new StringBuffer(length);
-        buffer.append(ch, start, length);
+        String string = new String(ch, start, length);
 
-        String string = new String(buffer);
-
-        char[] chars;
-        chars = new char[length];
-        chars = string.toCharArray();
+        char[] chars = string.toCharArray();
 
         contentMock.ignorableWhitespace(EasyMock.aryEq(chars), EasyMock.eq(0),
                 EasyMock.eq(length));


### PR DESCRIPTION
`StringBuffer` is *thread-safe* (chock full of `synchronized` methods), and often overkill for local variables never shared across threads.  `StringBuilder` is designed for use as a drop-in replacement for `StringBuffer` in places where the string buffer was being used by a single thread (as is generally the case). Where possible, it is recommended that `StringBuilder` be used in preference to `StringBuffer` as it will be faster under most implementations.