### PR TITLE
Removed StAX dependencies because they are built-in since Java 6.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -370,24 +370,6 @@
          </dependency>
 
          <dependency>
-            <groupId>stax</groupId>
-            <artifactId>stax</artifactId>
-            <version>1.2.0</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>javax.xml.stream</groupId>
-                  <artifactId>stax-api</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
-
-         <dependency>
-            <groupId>javax.xml.stream</groupId>
-            <artifactId>stax-api</artifactId>
-            <version>1.0-2</version>
-         </dependency>
-
-         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -113,16 +113,6 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>stax</groupId>
-            <artifactId>stax</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml.stream</groupId>
-            <artifactId>stax-api</artifactId>
-        </dependency>
         
         <!-- Spring -->
         <dependency>


### PR DESCRIPTION
See issue #18.