### PR TITLE
Replaced String.split with StringUtils.split.

### DIFF
--- a/codegen/src/main/java/org/exolab/castor/builder/printing/JClassPrinterFactoryRegistry.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/printing/JClassPrinterFactoryRegistry.java
@@ -18,6 +18,7 @@ package org.exolab.castor.builder.printing;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.exolab.castor.builder.BuilderConfiguration;
@@ -49,7 +50,7 @@ public class JClassPrinterFactoryRegistry {
      */
     public JClassPrinterFactoryRegistry(final BuilderConfiguration config) {
         String jClassPrinterFactories = config.getJClassPrinterFactories();
-        String[] factoryClassNames = jClassPrinterFactories.split(",");
+        String[] factoryClassNames = StringUtils.split(jClassPrinterFactories, ',');
         
         for (int i = 0; i < factoryClassNames.length; i++) {
             JClassPrinterFactory factory;

--- a/core/src/main/java/org/castor/core/util/AbstractProperties.java
+++ b/core/src/main/java/org/castor/core/util/AbstractProperties.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -559,7 +560,7 @@ public abstract class AbstractProperties {
         } else if (objectValue instanceof String[]) {
             return (String[]) objectValue;
         } else if (objectValue instanceof String) {
-            return ((String) objectValue).split(",");
+            return StringUtils.split((String) objectValue, ',');
         }
 
         Object[] args = new Object[] {key, objectValue};
@@ -627,7 +628,7 @@ public abstract class AbstractProperties {
         } else if (objectValue instanceof Class[]) {
             return (Class[]) objectValue;
         } else if (objectValue instanceof String) {
-            String[] classnames = ((String) objectValue).split(",");
+            String[] classnames = StringUtils.split((String) objectValue, ',');
             Class[] classes = new Class[classnames.length];
             for (int i = 0; i < classnames.length; i++) {
                 try {
@@ -686,7 +687,7 @@ public abstract class AbstractProperties {
             return (Object[]) objectValue;
         } else if (objectValue instanceof String) {
             List<Object> objects = new ArrayList<>();
-            String[] classnames = ((String) objectValue).split(",");
+            String[] classnames = StringUtils.split((String) objectValue, ',');
             for (int i = 0; i < classnames.length; i++) {
                 String classname = classnames[i];
                 try {

--- a/maven-plugins/src/main/java/org/codehaus/castor/maven/xmlctf/AbstractTestSuiteMojo.java
+++ b/maven-plugins/src/main/java/org/codehaus/castor/maven/xmlctf/AbstractTestSuiteMojo.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 
 import junit.framework.Test;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -152,7 +153,7 @@ public abstract class AbstractTestSuiteMojo extends AbstractMojo {
         }
 
         getLog().info("classpath for sourcegenerator is: " + classpath);
-        String[] classpathEntries = classpath.toString().split(";");
+        String[] classpathEntries = StringUtils.split(classpath.toString(), ';');
         for (String classpathEntry : classpathEntries) {
             getLog().info(classpathEntry);
         }


### PR DESCRIPTION
[String.split](http://docs.oracle.com/javase/7/docs/api/java/lang/String.html#split(java.lang.String)) supports *regular expressions*, but often calls are simply trying to split based on a single character, so [StringUtils.split](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/StringUtils.html#split(java.lang.String,%20char)) seems like a more prudent choice (no *regular expression matching* overhead).