### PR TITLE
Modernized code.

### DIFF
--- a/anttask/src/main/java/org/castor/anttask/CastorCodeGenTask.java
+++ b/anttask/src/main/java/org/castor/anttask/CastorCodeGenTask.java
@@ -122,7 +122,7 @@ public final class CastorCodeGenTask extends MatchingTask {
     private File _schemaDir = null;
     
     /** If processing a fileset, this lists the fileset. */
-    private Vector < FileSet > _schemaFilesets = new Vector < FileSet > ();
+    private Vector<FileSet> _schemaFilesets = new Vector<>();
 
     // Begin Source Generator parameters
     /** The package that generated code will belong to. */
@@ -239,7 +239,7 @@ public final class CastorCodeGenTask extends MatchingTask {
      * @param set An individual file set containing schemas.
      */
     public void addFileset(final FileSet set) {
-        _schemaFilesets.addElement(set);
+        _schemaFilesets.add(set);
     }
 
     /**
@@ -588,7 +588,7 @@ public final class CastorCodeGenTask extends MatchingTask {
      */
     public void execute() {
         // Must have something to run the source generator on
-        if (_schemaFile == null && _schemaDir == null && _schemaFilesets.size() == 0
+        if (_schemaFile == null && _schemaDir == null && _schemaFilesets.isEmpty()
                 && _schemaURL == null) {
             throw new BuildException(NO_SCHEMA_MSG);
         }

--- a/anttask/src/main/java/org/castor/anttask/XMLInstance2SchemaTask.java
+++ b/anttask/src/main/java/org/castor/anttask/XMLInstance2SchemaTask.java
@@ -59,7 +59,7 @@ public final class XMLInstance2SchemaTask extends MatchingTask {
     /** 
      * Enlists the fileset the user wants to process. 
      */
-    private Vector _xmlInstanceFileSets = new Vector();
+    private final Vector<FileSet> _xmlInstanceFileSets = new Vector<>();
 
     // Begin application-specific parameters
     
@@ -100,7 +100,7 @@ public final class XMLInstance2SchemaTask extends MatchingTask {
      * @param set An individual file set containing schemas.
      */
     public void addFileset(final FileSet set) {
-        _xmlInstanceFileSets.addElement(set);
+        _xmlInstanceFileSets.add(set);
     }
 
     /**
@@ -178,7 +178,7 @@ public final class XMLInstance2SchemaTask extends MatchingTask {
     public void execute() {
         // Must have something to run the source generator on
         if (_xmlInstanceFile == null && _xmlInstanceDir == null 
-                && _xmlInstanceFileSets.size() == 0) {
+                && _xmlInstanceFileSets.isEmpty()) {
             throw new BuildException(NO_XML_DOCUMENT_MSG);
         }
 

--- a/codegen/src/main/java/org/exolab/castor/builder/FactoryState.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/FactoryState.java
@@ -248,7 +248,7 @@ public class FactoryState implements ClassInfoResolver {
      *            processed.
      */
     public void markAsProcessed(final Annotated annotated) {
-        _processed.addElement(annotated);
+        _processed.add(annotated);
     } // -- markAsProcessed
 
     /**

--- a/codegen/src/main/java/org/exolab/castor/builder/JClassRegistry.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/JClassRegistry.java
@@ -427,7 +427,7 @@ public class JClassRegistry {
         LOG.info("*** Summary ***");
         if (binding.getBinding() != null 
                 && binding.getBinding().getForces() != null 
-                && binding.getBinding().getForces().size() > 0) {
+                && !binding.getBinding().getForces().isEmpty()) {
             Iterator<String> forceIterator = binding.getBinding().getForces().iterator();
             LOG.info("The following 'forces' have been enabled:");
             while (forceIterator.hasNext()) {

--- a/codegen/src/main/java/org/exolab/castor/builder/SGStateInfo.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/SGStateInfo.java
@@ -49,6 +49,7 @@
  */
 package org.exolab.castor.builder;
 
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -73,7 +74,7 @@ import org.exolab.javasource.JClass;
 public final class SGStateInfo extends ClassInfoResolverImpl {
 
     /** An empty Enumeration to be returned whenever we need an empty Enumeration. */
-    private static final Enumeration<String> EMPTY_ENUMERATION = new Vector<String>(0).elements();
+    private static final Enumeration<String> EMPTY_ENUMERATION = Collections.emptyEnumeration();
     /** The SourceGenerator is still generating source. */
     public static final int NORMAL_STATUS = 0;
     /** The SourceGenerator has been stopped by an error or by the user. */
@@ -300,7 +301,7 @@ public final class SGStateInfo extends ClassInfoResolverImpl {
     void markAsProcessed(final JClass jClass) {
         //String className = jClass.getName();
         if (!_processed.contains(jClass)) {
-            _processed.addElement(jClass);
+            _processed.add(jClass);
         }
     } //-- markAsProcessed
 

--- a/codegen/src/main/java/org/exolab/castor/builder/factory/CollectionMemberAndAccessorFactory.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/factory/CollectionMemberAndAccessorFactory.java
@@ -48,12 +48,13 @@ public class CollectionMemberAndAccessorFactory extends FieldMemberAndAccessorFa
         sourceCode.append("();");
         
         if (!StringUtils.isEmpty(fieldInfo.getDefaultValue())) {
-          StringBuffer buffer = new StringBuffer();
-          buffer.append(fieldInfo.getName());
-          buffer.append(".add(");
-          buffer.append(fieldInfo.getDefaultValue());
-          buffer.append(");");
-          sourceCode.add(buffer.toString());
+          String buffer = new StringBuilder()
+              .append(fieldInfo.getName())
+              .append(".add(")
+              .append(fieldInfo.getDefaultValue())
+              .append(");")
+              .toString();
+          sourceCode.add(buffer);
         }
     } // -- generateConstructorCode
 

--- a/codegen/src/main/java/org/exolab/castor/builder/factory/EnumerationFactory.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/factory/EnumerationFactory.java
@@ -254,15 +254,16 @@ public final class EnumerationFactory extends BaseFactory {
                 if (generateConstantDefinitions) {
                     jsc.append(objName);
                 } else {
-                    StringBuilder init = new StringBuilder(32);
-                    init.append("new ");
-                    init.append(className);
-                    init.append("(");
-                    init.append(Integer.toString(count));
-                    init.append(", \"");
-                    init.append(escapeValue(value));
-                    init.append("\")");
-                    jsc.append(init.toString());
+                    String init = new StringBuilder(32)
+                        .append("new ")
+                        .append(className)
+                        .append('(')
+                        .append(count)
+                        .append(", \"")
+                        .append(escapeValue(value))
+                        .append("\")")
+                        .toString();
+                    jsc.append(init);
                 }
                 jsc.append(");");
             }

--- a/codegen/src/main/java/org/exolab/castor/builder/factory/FieldMemberAndAccessorFactory.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/factory/FieldMemberAndAccessorFactory.java
@@ -87,12 +87,12 @@ public class FieldMemberAndAccessorFactory {
                  * with 'add' (for multivalued fields) or 'set'! 
                  * @see FieldInfo#getWriteMethodeName() 
                  */ 
-                buffer.append(fieldInfo.getWriteMethodName());
+                buffer.append(fieldInfo.getWriteMethodName())
                 //buffer.append(FieldInfo.METHOD_PREFIX_SET);
                 //buffer.append(fieldInfo.getMethodSuffix());
-                buffer.append('(');
-                buffer.append(value);
-                buffer.append(");");
+                    .append('(')
+                    .append(value)
+                    .append(");");
                 jsc.add(buffer.toString());
                 if (dateTime) {
                     jsc.unindent();

--- a/codegen/src/main/java/org/exolab/castor/builder/info/ClassInfo.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/info/ClassInfo.java
@@ -77,21 +77,21 @@ public final class ClassInfo implements XMLInfo, PropertyHolder {
     private boolean _abstract    = false;
     
     /** Vector of FieldInfo's for all attributes that are members of this Class. */
-    private Vector<FieldInfo> _atts = new Vector<FieldInfo>();
+    private final Vector<FieldInfo> _atts = new Vector<FieldInfo>();
     /** Vector of FieldInfo's for all elements that are members of this Class. */
-    private Vector<FieldInfo> _elements = new Vector<FieldInfo>();
+    private final Vector<FieldInfo> _elements = new Vector<FieldInfo>();
     /** if this ClassInfo represents a TextField, this is this TextField's FieldInfo. */
     private FieldInfo _textField = null;
     
     /**
      * Map holding the properties set and read by Natures.
      */
-    private Map<String, Object> _properties = new HashMap<String, Object>();
+    private final Map<String, Object> _properties = new HashMap<String, Object>();
     
     /**
      * Map holding the available natures.
      */
-    private Set<String> _natures = new HashSet<String>();
+    private final Set<String> _natures = new HashSet<String>();
 
     /**
      * Creates a new ClassInfo. Adds the {@link XMLInfoNature} for legacy compliance.
@@ -126,7 +126,7 @@ public final class ClassInfo implements XMLInfo, PropertyHolder {
         switch(new XMLInfoNature(fieldInfo).getNodeType()) {
             case ATTRIBUTE:
                 if (!_atts.contains(fieldInfo)) {
-                    _atts.addElement(fieldInfo);
+                    _atts.add(fieldInfo);
                 }
                 break;
             case TEXT:
@@ -134,7 +134,7 @@ public final class ClassInfo implements XMLInfo, PropertyHolder {
                 break;
             default:
                 if (!_elements.contains(fieldInfo)) {
-                    _elements.addElement(fieldInfo);
+                    _elements.add(fieldInfo);
                 }
                 break;
         }
@@ -196,14 +196,9 @@ public final class ClassInfo implements XMLInfo, PropertyHolder {
      * @return an array of XML attribute associated fields.
      */
     public FieldInfo[] getAttributeFields() {
-        FieldInfo[] fields = null;
-        if (_atts != null) {
-            fields = new FieldInfo[_atts.size()];
-            _atts.copyInto(fields);
-        } else {
-            fields = new FieldInfo[0];
-        }
-        return fields;
+        return null != _atts
+            ? _atts.toArray(new FieldInfo[_atts.size()])
+            : new FieldInfo[0];
     } //-- getAttributeFields
 
     /**
@@ -218,8 +213,7 @@ public final class ClassInfo implements XMLInfo, PropertyHolder {
             return null;
         }
 
-        for (int i = 0; i < _atts.size(); i++) {
-            FieldInfo temp = _atts.get(i);
+        for (FieldInfo temp : _atts) {
             if (new XMLInfoNature(temp).getNodeName().equals(nodeName)) {
                 return temp;
             }
@@ -245,14 +239,9 @@ public final class ClassInfo implements XMLInfo, PropertyHolder {
      * @return an array of XML element associated fields.
      */
     public FieldInfo[] getElementFields() {
-        FieldInfo[] members = null;
-        if (_elements != null) {
-            members = new FieldInfo[_elements.size()];
-            _elements.copyInto(members);
-        } else {
-            members = new FieldInfo[0];
-        }
-        return members;
+        return null != _elements
+            ? _elements.toArray(new FieldInfo[_elements.size()])
+            : new FieldInfo[0];
     } //-- getElementFields
 
     /**

--- a/codegen/src/main/java/org/exolab/castor/builder/printing/TemplateHelper.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/printing/TemplateHelper.java
@@ -102,11 +102,11 @@ public class TemplateHelper {
      * @return A string representation of the annotation.
      */
     public String printAnnotation(final JAnnotation annotation, String shift) {
-        StringBuilder stringBuffer = new StringBuilder(32);
-        stringBuffer.append(shift);
-        stringBuffer.append("@");
-        stringBuffer.append(annotation.getAnnotationType().getLocalName());
-        stringBuffer.append("(");
+        StringBuilder stringBuffer = new StringBuilder(32)
+            .append(shift)
+            .append("@")
+            .append(annotation.getAnnotationType().getLocalName())
+            .append("(");
         // Single element annotation?
         String[] elementNames = annotation.getElementNames();
         if (elementNames.length == 1 && elementNames[0].equals(JAnnotation.VALUE)) {
@@ -120,28 +120,27 @@ public class TemplateHelper {
                 if (elementNameLength > maxLength) { maxLength = elementNameLength; }
             }
             // Output element name and values
-            stringBuffer.append("\n");
-            stringBuffer.append(shift + "    ");
+            stringBuffer.append('\n')
+                .append(shift + "    ");
             for (int i = 0; i < elementNames.length; i++) {
                 int elementNameLength = elementNames[i].length();
                 // Output element name with padding
                 stringBuffer.append(elementNames[i]);
                 for (int p = 0; p < maxLength - elementNameLength; p++) {
-                    stringBuffer.append(" ");
+                    stringBuffer.append(' ');
                 }
                 // Assignment operator
-                stringBuffer.append(" = ");
+                stringBuffer.append(" = ")
                 // Value
-                stringBuffer.append(printAnnotationValue(
+                    .append(printAnnotationValue(
                         annotation.getElementValueObject(elementNames[i]), shift));
                 if (i < elementNames.length - 1) {
-                    stringBuffer.append(",");
-                    stringBuffer.append("\n");
-                    stringBuffer.append(shift + "    ");
+                    stringBuffer.append(",\n")
+                        .append(shift + "    ");
                 }
             }
         }
-        stringBuffer.append(")");
+        stringBuffer.append(')');
         return stringBuffer.toString();
     }
     
@@ -166,18 +165,16 @@ public class TemplateHelper {
                 return printAnnotationValue(Array.get(elementValue, 0), shift);
             }
             // Output list items
-            StringBuilder stringBuffer = new StringBuilder();
-            stringBuffer.append("\n");
-            stringBuffer.append("{");
-            stringBuffer.append("\n");
-            stringBuffer.append(shift);
+            StringBuilder stringBuffer = new StringBuilder()
+                .append("\n{\n")
+                .append(shift);
             for (int i = 0; i < listLength; i++) {
-                stringBuffer.append(shift);
-                stringBuffer.append(printAnnotationValue(Array.get(elementValue, i), shift));
-                if (i < listLength - 1) { stringBuffer.append(","); }
-                stringBuffer.append("\n");
+                stringBuffer.append(shift)
+                    .append(printAnnotationValue(Array.get(elementValue, i), shift));
+                if (i < listLength - 1) { stringBuffer.append(','); }
+                stringBuffer.append('\n');
             }
-            stringBuffer.append("}");
+            stringBuffer.append('}');
             return stringBuffer.toString();
         }
         throw new IllegalArgumentException("'" + elementValue + "' was not expected.");

--- a/codegen/src/main/java/org/exolab/javasource/AbstractJClass.java
+++ b/codegen/src/main/java/org/exolab/javasource/AbstractJClass.java
@@ -15,7 +15,9 @@
  */
 package org.exolab.javasource;
 
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Vector;
@@ -32,24 +34,24 @@ import org.exolab.castor.builder.SourceGenerator;
 public abstract class AbstractJClass extends JStructure {
 
     /** The source code for static initialization. */
-    private JSourceCode _staticInitializer;
+    private final JSourceCode _staticInitializer = new JSourceCode();
 
     /** The list of member variables (fields) of this JClass. */
-    private Map<String, JField> _fields = new LinkedHashMap<String, JField>();
+    private final Map<String, JField> _fields = new LinkedHashMap<String, JField>();
 
     /** The list of member constants of this {@link JClass}. */
-    private Map<String, JConstant> _constants = new LinkedHashMap<String, JConstant>();
+    private final Map<String, JConstant> _constants = new LinkedHashMap<String, JConstant>();
 
     /** The list of constructors for this JClass. */
-    private Vector<JConstructor> _constructors;
+    private final Vector<JConstructor> _constructors = new Vector<JConstructor>();
 
     /** The list of methods of this JClass. */
-    private Vector<JMethod> _methods;
+    private final Vector<JMethod> _methods = new Vector<JMethod>();
 
     /** A collection of inner classes for this JClass. */
     private Vector<JClass> _innerClasses;
 
-    private Vector<String> _sourceCodeEntries = new Vector<String>();
+    private final Vector<String> _sourceCodeEntries = new Vector<String>();
 
     /**
      * Returns a collection of (complete) source code fragments.
@@ -75,10 +77,6 @@ public abstract class AbstractJClass extends JStructure {
      */
     protected AbstractJClass(final String name, boolean useOldFieldNaming) {
         super(name);
-        
-        _staticInitializer = new JSourceCode();
-        _constructors = new Vector<JConstructor>();
-        _methods = new Vector<JMethod>();
         _innerClasses = null;
         
         if (useOldFieldNaming) {
@@ -335,7 +333,7 @@ public abstract class AbstractJClass extends JStructure {
 
             /** check signatures (add later) **/
             if (!_constructors.contains(constructor)) {
-                _constructors.addElement(constructor);
+                _constructors.add(constructor);
             }
         } else {
             String err = "The given JConstructor was not created by this JClass";
@@ -350,7 +348,7 @@ public abstract class AbstractJClass extends JStructure {
      * @return true if the constructor was removed, otherwise false.
      */
     public final boolean removeConstructor(final JConstructor constructor) {
-        return _constructors.removeElement(constructor);
+        return _constructors.remove(constructor);
     }
 
     /**
@@ -359,13 +357,7 @@ public abstract class AbstractJClass extends JStructure {
      * @return An array of all the JMethods of this JClass.
      */
     public final JMethod[] getMethods() {
-        int size = _methods.size();
-        JMethod[] marray = new JMethod[size];
-
-        for (int i = 0; i < _methods.size(); i++) {
-            marray[i] = _methods.elementAt(i);
-        }
-        return marray;
+        return _methods.toArray(new JMethod[_methods.size()]);
     }
 
     /**
@@ -440,7 +432,7 @@ public abstract class AbstractJClass extends JStructure {
             }
         }
         //-- END SORT
-        if (!added) { _methods.addElement(jMethod); }
+        if (!added) { _methods.add(jMethod); }
 
     }
 
@@ -459,7 +451,9 @@ public abstract class AbstractJClass extends JStructure {
      * @param jMethods The JMethod[] to add.
      */
     public final void addMethods(final JMethod[] jMethods) {
-        for (int i = 0; i < jMethods.length; i++) { addMethod(jMethods[i]); }
+        for (JMethod jMethod : jMethods) {
+            addMethod(jMethod);
+        }
     }
 
     /**
@@ -469,7 +463,7 @@ public abstract class AbstractJClass extends JStructure {
      * @return true if the method was removed, otherwise false.
      */
     public final boolean removeMethod(final JMethod method) {
-        return _methods.removeElement(method);
+        return _methods.remove(method);
     }
 
     /**
@@ -489,7 +483,7 @@ public abstract class AbstractJClass extends JStructure {
         }
         String classname = getPackageName();
         if (classname != null) {
-            classname = classname + "." + localname;
+            classname = classname + '.' + localname;
         } else {
             classname = localname;
         }
@@ -498,7 +492,7 @@ public abstract class AbstractJClass extends JStructure {
         if (_innerClasses == null) {
             _innerClasses = new Vector<JClass>();
         }
-        _innerClasses.addElement(innerClass);
+        _innerClasses.add(innerClass);
         return innerClass;
 
     }
@@ -510,22 +504,15 @@ public abstract class AbstractJClass extends JStructure {
      * @return An array of JClass contained within this JClass.
      */
     public final JClass[] getInnerClasses() {
-        if (_innerClasses != null) {
-            int size = _innerClasses.size();
-            JClass[] carray = new JClass[size];
-            _innerClasses.copyInto(carray);
-            return carray;
-        }
-        return new JClass[0];
+        return null != _innerClasses
+            ? _innerClasses.toArray(new JClass[_innerClasses.size()])
+            : new JClass[0];
     }
     
     public final int getInnerClassCount() {
-    	if (_innerClasses != null) {
-    		return _innerClasses.size();
-    	} 
-    	return 0;
-    	
-    		
+        return null != _innerClasses
+            ? _innerClasses.size()
+            : 0;
     }
 
     /**
@@ -535,10 +522,9 @@ public abstract class AbstractJClass extends JStructure {
      * @return true if the JClass was removed, otherwise false.
      */
     public final boolean removeInnerClass(final JClass jClass) {
-        if (_innerClasses != null) {
-            return _innerClasses.removeElement(jClass);
-        }
-        return false;
+        return null != _innerClasses
+            ? _innerClasses.remove(jClass)
+            : false;
     }
 
     //--------------------------------------------------------------------------
@@ -575,11 +561,10 @@ public abstract class AbstractJClass extends JStructure {
         printPackageDeclaration(jsw);
 
         //-- get imports from inner-classes
-        Vector<String> removeImports = null;
+        List<String> removeImports = null;
         if ((_innerClasses != null) && (_innerClasses.size() > 0)) {
-            removeImports = new Vector<String>();
-            for (int i = 0; i < _innerClasses.size(); i++) {
-                JClass iClass = _innerClasses.elementAt(i);
+            removeImports = new ArrayList<>();
+            for (JClass iClass : _innerClasses) {
                 Enumeration<String> enumeration = iClass.getImports();
                 while (enumeration.hasMoreElements()) {
                     String classname = enumeration.nextElement();
@@ -590,7 +575,7 @@ public abstract class AbstractJClass extends JStructure {
                     }
                     if (!hasImport(classname)) {
                         addImport(classname);
-                        removeImports.addElement(classname);
+                        removeImports.add(classname);
                     }
                 }
             }
@@ -600,8 +585,8 @@ public abstract class AbstractJClass extends JStructure {
 
         //-- remove imports from inner-classes, if necessary
         if (removeImports != null) {
-            for (int i = 0; i < removeImports.size(); i++) {
-                removeImport(removeImports.elementAt(i));
+            for (String imp : removeImports) {
+                removeImport(imp);
             }
         }
     }
@@ -689,8 +674,7 @@ public abstract class AbstractJClass extends JStructure {
      * @param jsw The JSourceWriter to be used.
      */
     protected final void printConstructors(final JSourceWriter jsw) {
-        for (int i = 0; i < _constructors.size(); i++) {
-            JConstructor jConstructor = _constructors.elementAt(i);
+        for (JConstructor jConstructor : _constructors) {
             jConstructor.print(jsw);
             jsw.writeln();
         }
@@ -702,8 +686,7 @@ public abstract class AbstractJClass extends JStructure {
      * @param jsw The JSourceWriter to be used.
      */
     protected final void printMethods(final JSourceWriter jsw) {
-        for (int i = 0; i < _methods.size(); i++) {
-            JMethod jMethod = _methods.elementAt(i);
+        for (JMethod jMethod : _methods) {
             jMethod.print(jsw);
             jsw.writeln();
         }
@@ -723,9 +706,8 @@ public abstract class AbstractJClass extends JStructure {
      * @param jsw The JSourceWriter to be used.
      */
     protected final void printInnerClasses(final JSourceWriter jsw) {
-        if ((_innerClasses != null) && (_innerClasses.size() > 0)) {
-            for (int i = 0; i < _innerClasses.size(); i++) {
-                JClass jClass = _innerClasses.elementAt(i);
+        if (_innerClasses != null && !_innerClasses.isEmpty()) {
+            for (JClass jClass : _innerClasses) {
                 jClass.print(jsw, true);
                 jsw.writeln();
             }

--- a/codegen/src/main/java/org/exolab/javasource/AbstractJField.java
+++ b/codegen/src/main/java/org/exolab/javasource/AbstractJField.java
@@ -203,13 +203,12 @@ public class AbstractJField extends JAnnotatedElementHelper implements JMember {
      * {@inheritDoc}
      */
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(_modifiers.toString());
-        sb.append(' ');
-        sb.append(_type);
-        sb.append(' ');
-        sb.append(_name);
-        return sb.toString();
+        return new StringBuilder()
+            .append(_modifiers)
+            .append(' ')
+            .append(_type)
+            .append(' ')
+            .append(_name)
+            .toString();
     }
-
 }

--- a/codegen/src/main/java/org/exolab/javasource/JAnnotatedElementHelper.java
+++ b/codegen/src/main/java/org/exolab/javasource/JAnnotatedElementHelper.java
@@ -119,7 +119,7 @@ public class JAnnotatedElementHelper implements JAnnotatedElement {
      * {@inheritDoc}
      */
     public final boolean hasAnnotations() {
-        return _annotations.size() > 0;
+        return !_annotations.isEmpty();
     }
 
     /**

--- a/codegen/src/main/java/org/exolab/javasource/JCodeStatement.java
+++ b/codegen/src/main/java/org/exolab/javasource/JCodeStatement.java
@@ -76,7 +76,7 @@ public final class JCodeStatement {
         }
         StringBuilder sb = new StringBuilder(_indentSize + _value.length());
         for (int i = 0; i < _indentSize; i++) { sb.append(' '); }
-        sb.append(_value.toString());
+        sb.append(_value);
         return sb.toString();
     }
 

--- a/codegen/src/main/java/org/exolab/javasource/JCollectionType.java
+++ b/codegen/src/main/java/org/exolab/javasource/JCollectionType.java
@@ -92,12 +92,12 @@ public final class JCollectionType extends JComponentizedType {
             if (isUseJava50()) {
                 if (getComponentType().isPrimitive()) {
                     JPrimitiveType primitive = (JPrimitiveType) getComponentType();
-                    return _instanceName + "<" + primitive.getWrapperName() + ">";
+                    return _instanceName + '<' + primitive.getWrapperName() + '>';
                 }
                 if (_useExtends) {
-                    return _instanceName + "<? extends " + getComponentType().toString() + ">";
+                    return _instanceName + "<? extends " + getComponentType() + '>';
                 }
-                return _instanceName + "<" + getComponentType().toString() + ">";
+                return _instanceName + '<' + getComponentType() + '>';
             }
 
             return _instanceName;
@@ -115,12 +115,12 @@ public final class JCollectionType extends JComponentizedType {
         if (isUseJava50()) {
             if (getComponentType().isPrimitive()) {
                 JPrimitiveType primitive = (JPrimitiveType) getComponentType();
-                return getName() + "<" + primitive.getWrapperName() + ">";
+                return getName() + '<' + primitive.getWrapperName() + '>';
             } 
             if (_useExtends) {
-                return getName() + "<? extends " + getComponentType().toString() + ">";
+                return getName() + "<? extends " + getComponentType() + '>';
             }
-            return getName() + "<" + getComponentType().toString() + ">";
+            return getName() + '<' + getComponentType() + '>';
         }
         
         return getName();

--- a/codegen/src/main/java/org/exolab/javasource/JCompUnit.java
+++ b/codegen/src/main/java/org/exolab/javasource/JCompUnit.java
@@ -234,11 +234,9 @@ public final class JCompUnit {
      * @return The name of the file that this JCompUnit would be printed to.
      */
     public String getFilename(final String destDir) {
-        String filename = new String(_fileName);
-
         // -- Convert Java package to path string
         String javaPackagePath = "";
-        if ((_packageName != null) && (_packageName.length() > 0)) {
+        if (_packageName != null && !_packageName.isEmpty()) {
             javaPackagePath = _packageName.replace('.', File.separatorChar);
         }
 
@@ -254,8 +252,10 @@ public final class JCompUnit {
         }
 
         // -- Prefix filename with path
-        if (pathFile.toString().length() > 0) {
-            filename = pathFile.toString() + File.separator + filename;
+        String filename = _fileName;        
+        final String pathStr = pathFile.toString();
+        if (!pathStr.isEmpty()) {
+            filename = pathStr + File.separator + filename;
         }
 
         return filename;
@@ -336,8 +336,6 @@ public final class JCompUnit {
         // Traverse the nested class and interface hiararchy and
         // update the names to match the compilation unit.
 
-        StringBuilder buffer = new StringBuilder(INITIAL_STRING_BUILDER_SIZE);
-
         // -- write file header
         if (_header != null) {
             _header.print(jsw);
@@ -351,11 +349,12 @@ public final class JCompUnit {
 
         // -- print package name
         if ((_packageName != null) && (_packageName.length() > 0)) {
-            buffer.setLength(0);
-            buffer.append("package ");
-            buffer.append(_packageName);
-            buffer.append(';');
-            jsw.writeln(buffer.toString());
+            String buffer = new StringBuilder(INITIAL_STRING_BUILDER_SIZE)
+                .append("package ")
+                .append(_packageName)
+                .append(';')
+                .toString();
+            jsw.writeln(buffer);
             jsw.writeln();
         }
 
@@ -368,7 +367,7 @@ public final class JCompUnit {
         String compUnitPackage = getPackageName();
         for (String importName : allImports) {
             String importsPackage = JNaming.getPackageFromClassName(importName);
-            if ((importsPackage != null) && !importsPackage.equals(compUnitPackage)) {
+            if (importsPackage != null && !importsPackage.equals(compUnitPackage)) {
                 jsw.write("import ");
                 jsw.write(importName);
                 jsw.writeln(';');

--- a/codegen/src/main/java/org/exolab/javasource/JCompUnit.java
+++ b/codegen/src/main/java/org/exolab/javasource/JCompUnit.java
@@ -85,16 +85,16 @@ public final class JCompUnit {
     private JComment _header = null;
 
     /** The package for this JCompUnit. */
-    private String _packageName = null;
+    private final String _packageName;
 
     /** The file to which this JCompUnit will be written. */
-    private String _fileName = null;
+    private final String _fileName;
 
     /** The set of top-level classes that live in this compilation unit. */
-    private Vector<JClass> _classes = new Vector<JClass>();
+    private final Vector<JClass> _classes = new Vector<JClass>();
 
     /** The set of top-level interfaces that live in this compilation unit. */
-    private Vector<JInterface> _interfaces = new Vector<JInterface>();
+    private final Vector<JInterface> _interfaces = new Vector<JInterface>();
 
     /**
      * Creates a new JCompUnit.
@@ -116,7 +116,7 @@ public final class JCompUnit {
      * @param jClass The public class for this JCompUnit.
      */
     public JCompUnit(final JClass jClass) {
-        _packageName = jClass.getPackageName();
+        this(jClass.getPackageName(), jClass.getLocalName() + ".java");
 
         // The outer name is the package plus the simple name of the
         // outermost enclosing class. The file name is just the
@@ -135,9 +135,6 @@ public final class JCompUnit {
         // filePrefix = outer;
         // }
 
-        String filePrefix = jClass.getLocalName();
-
-        _fileName = filePrefix + ".java";
         _classes.add(jClass);
     }
 
@@ -148,8 +145,7 @@ public final class JCompUnit {
      * @param jInterface The public interface for this JCompUnit.
      */
     public JCompUnit(final JInterface jInterface) {
-        _packageName = jInterface.getPackageName();
-        _fileName = jInterface.getLocalName() + ".java";
+        this(jInterface.getPackageName(), jInterface.getLocalName() + ".java");
         _interfaces.add(jInterface);
     }
 

--- a/codegen/src/main/java/org/exolab/javasource/JConstructor.java
+++ b/codegen/src/main/java/org/exolab/javasource/JConstructor.java
@@ -55,19 +55,19 @@ import java.util.Vector;
 public final class JConstructor extends JAnnotatedElementHelper {
 
     /** The set of modifiers for this JConstructor. */
-    private JModifiers _modifiers;
+    private JModifiers _modifiers = new JModifiers();
     
     /** List of parameters for this JConstructor. */
-    private Map<String, JParameter> _params = new LinkedHashMap<String, JParameter>();
+    private final Map<String, JParameter> _params = new LinkedHashMap<String, JParameter>();
     
     /** The Class in this JConstructor has been declared. */
-    private AbstractJClass _declaringClass;
+    private final AbstractJClass _declaringClass;
     
     /** The source code for this constructor. */
-    private JSourceCode _sourceCode;
+    private JSourceCode _sourceCode = new JSourceCode();
     
     /** The exceptions that this JConstructor throws. */
-    private Vector<JClass> _exceptions;
+    private final Vector<JClass> _exceptions = new Vector<>(1);
 
     /**
      * Creates a new JConstructor for the provided declaring class.
@@ -76,9 +76,6 @@ public final class JConstructor extends JAnnotatedElementHelper {
      */
     protected JConstructor(final AbstractJClass declaringClass) {
         _declaringClass = declaringClass;
-        _modifiers = new JModifiers();
-        _sourceCode = new JSourceCode();
-        _exceptions = new Vector<JClass>(1);
     }
 
     /**
@@ -87,9 +84,7 @@ public final class JConstructor extends JAnnotatedElementHelper {
      * @return The exceptions that this JConstructor lists in its throws clause.
      */
     public JClass[] getExceptions() {
-        JClass[] jclasses = new JClass[_exceptions.size()];
-        _exceptions.copyInto(jclasses);
-        return jclasses;
+        return _exceptions.toArray(new JClass[_exceptions.size()]);
     }
 
     /**
@@ -102,12 +97,11 @@ public final class JConstructor extends JAnnotatedElementHelper {
 
         //-- make sure exception is not already added
         String expClassName = exp.getName();
-        for (int i = 0; i < _exceptions.size(); i++) {
-            JClass jClass = _exceptions.elementAt(i);
+        for (JClass jClass : _exceptions) {
             if (expClassName.equals(jClass.getName())) { return; }
         }
         //-- add exception
-        _exceptions.addElement(exp);
+        _exceptions.add(exp);
     }
 
     /**
@@ -140,12 +134,13 @@ public final class JConstructor extends JAnnotatedElementHelper {
 
         //-- check current params
         if (_params.get(parameter.getName()) != null) {
-            StringBuilder err = new StringBuilder(64);
-            err.append("A parameter already exists for the constructor, ");
-            err.append(this._declaringClass.getName());
-            err.append(", with the name: ");
-            err.append(parameter.getName());
-            throw new IllegalArgumentException(err.toString());
+            String err = new StringBuilder(64)
+                .append("A parameter already exists for the constructor, ")
+                .append(this._declaringClass.getName())
+                .append(", with the name: ")
+                .append(parameter.getName())
+                .toString();
+            throw new IllegalArgumentException(err);
         }
 
         _params.put(parameter.getName(), parameter);
@@ -203,7 +198,7 @@ public final class JConstructor extends JAnnotatedElementHelper {
      * @param sourceCode Source code to apply to this constructor.
      */
     public void setSourceCode(final String sourceCode) {
-        _sourceCode = new JSourceCode(sourceCode);
+        setSourceCode(new JSourceCode(sourceCode));
     }
 
     /**
@@ -266,7 +261,7 @@ public final class JConstructor extends JAnnotatedElementHelper {
         }
 
         jsw.write(")");
-        if (_exceptions.size() > 0) {
+        if (!_exceptions.isEmpty()) {
             jsw.writeln();
             jsw.write("throws ");
             for (int i = 0; i < _exceptions.size(); i++) {
@@ -287,9 +282,9 @@ public final class JConstructor extends JAnnotatedElementHelper {
      * {@inheritDoc}
      */
     public String toString() {
-        StringBuilder sb = new StringBuilder(32);
-        sb.append(_declaringClass.getName());
-        sb.append('(');
+        StringBuilder sb = new StringBuilder(32)
+            .append(_declaringClass.getName())
+            .append('(');
 
         //-- print parameters
         for (int i = 0; i < _params.size(); i++) {

--- a/codegen/src/main/java/org/exolab/javasource/JDocComment.java
+++ b/codegen/src/main/java/org/exolab/javasource/JDocComment.java
@@ -55,10 +55,10 @@ public final class JDocComment {
     //--------------------------------------------------------------------------
 
     /** An ordered list of descriptors. */
-    private Vector<JDocDescriptor> _descriptors = null;
+    private final Vector<JDocDescriptor> _descriptors = new Vector<JDocDescriptor>();
     
     /** The internal buffer for this JDocComment. */
-    private StringBuffer _comment     = null;
+    private final StringBuffer _comment = new StringBuffer();
 
     //--------------------------------------------------------------------------
 
@@ -67,9 +67,6 @@ public final class JDocComment {
      */
     public JDocComment() {
         super();
-        
-        _descriptors = new Vector<JDocDescriptor>();
-        _comment     = new StringBuffer();
     }
 
     /**
@@ -78,11 +75,7 @@ public final class JDocComment {
      * @param jdesc The JDocDescriptor to add.
      */
     public JDocComment(final JDocDescriptor jdesc) {
-        super();
-        
-        _descriptors = new Vector<JDocDescriptor>();
-        _comment = new StringBuffer();
-        
+        this();
         addDescriptor(jdesc);
     }
 
@@ -96,8 +89,8 @@ public final class JDocComment {
     public void addDescriptor(final JDocDescriptor jdesc) {
         if (jdesc == null) { return; }
         //-- on the fly sorting of descriptors
-        if (_descriptors.size() == 0) {
-            _descriptors.addElement(jdesc);
+        if (_descriptors.isEmpty()) {
+            _descriptors.add(jdesc);
             return;
         }
 
@@ -202,7 +195,7 @@ public final class JDocComment {
         jComment.setComment(_comment.toString());
 
         //-- force a separating "*" for readability
-        if (_descriptors.size() > 0) {
+        if (!_descriptors.isEmpty()) {
             jComment.appendComment("\n");
         }
 
@@ -217,11 +210,10 @@ public final class JDocComment {
      * {@inheritDoc}
      */
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("/**\n");
-        sb.append(" * ");
-        sb.append(" */\n");
-        return sb.toString();
+        return
+            "/**\n" +
+            " * " +
+            " */\n";
     }
 
     //--------------------------------------------------------------------------

--- a/codegen/src/main/java/org/exolab/javasource/JEnum.java
+++ b/codegen/src/main/java/org/exolab/javasource/JEnum.java
@@ -195,12 +195,12 @@ public final class JEnum extends JClass {
             buffer.append("public ");
         }
 
-        buffer.append("enum ");
-        buffer.append(getLocalName());
-        buffer.append(' ');
+        buffer.append("enum ")
+            .append(getLocalName())
+            .append(' ');
         if (getInterfaceCount() > 0) {
             boolean endl = false;
-            if ((getInterfaceCount() > 1)) {
+            if (getInterfaceCount() > 1) {
                 jsw.writeln(buffer.toString());
                 buffer.setLength(0);
                 endl = true;
@@ -222,7 +222,6 @@ public final class JEnum extends JClass {
 
         buffer.append('{');
         jsw.writeln(buffer.toString());
-        buffer.setLength(0);
     }
 
     /**

--- a/codegen/src/main/java/org/exolab/javasource/JEnumConstant.java
+++ b/codegen/src/main/java/org/exolab/javasource/JEnumConstant.java
@@ -60,10 +60,10 @@ public final class JEnumConstant extends JAnnotatedElementHelper implements JMem
     private String[] _arguments;
     
     /** JavaDoc comment for this JEnumConstant. */
-    private JDocComment _comment;
+    private JDocComment _comment = new JDocComment();
     
     /** A list of methods attached to this JEnumConstant. */
-    private Vector<JMethod> _methods = null;
+    private final Vector<JMethod> _methods = new Vector<>();
 
     //--------------------------------------------------------------------------
 
@@ -86,8 +86,6 @@ public final class JEnumConstant extends JAnnotatedElementHelper implements JMem
     public JEnumConstant(final String name, final String[] arguments) {
         setName(name);
         
-        _methods = new Vector<JMethod>();
-        _comment = new JDocComment();
         _comment.appendComment("Constant " + name);
         _arguments = arguments;
     }
@@ -181,7 +179,7 @@ public final class JEnumConstant extends JAnnotatedElementHelper implements JMem
             }
         }
         //-- END SORT
-        if (!added) { _methods.addElement(jMethod); }
+        if (!added) { _methods.add(jMethod); }
     }
 
     /**
@@ -190,8 +188,8 @@ public final class JEnumConstant extends JAnnotatedElementHelper implements JMem
      * @param jMethods The array of JMethod to add.
      */
     public void addMethods(final JMethod[] jMethods) {
-        for (int i = 0; i < jMethods.length; i++) {
-            addMethod(jMethods[i]);
+        for (JMethod jMethod : jMethods) {
+            addMethod(jMethod);
         }
     }
 
@@ -323,7 +321,7 @@ public final class JEnumConstant extends JAnnotatedElementHelper implements JMem
             jsw.write(")");
         }
         //-- print methods
-        if (_methods.size() > 0) {
+        if (!_methods.isEmpty()) {
             jsw.write(" {");
             jsw.writeln();
             jsw.indent();

--- a/codegen/src/main/java/org/exolab/javasource/JInterface.java
+++ b/codegen/src/main/java/org/exolab/javasource/JInterface.java
@@ -314,8 +314,6 @@ public final class JInterface extends JStructure {
 
         getAnnotatedElementHelper().printAnnotations(jsw);
 
-        buffer.setLength(0);
-
         JModifiers modifiers = getModifiers();
         if (modifiers.isPrivate()) {
             buffer.append("private ");
@@ -327,9 +325,9 @@ public final class JInterface extends JStructure {
             buffer.append("abstract ");
         }
 
-        buffer.append("interface ");
-        buffer.append(getLocalName());
-        buffer.append(' ');
+        buffer.append("interface ")
+            .append(getLocalName())
+            .append(' ');
         if (getInterfaceCount() > 0) {
             Enumeration<String> enumeration = getInterfaces();
             boolean endl = false;

--- a/codegen/src/main/java/org/exolab/javasource/JInterface.java
+++ b/codegen/src/main/java/org/exolab/javasource/JInterface.java
@@ -60,10 +60,10 @@ import java.util.Vector;
 public final class JInterface extends JStructure {
 
     /** The fields for this JInterface. */
-    private Map<String, JField> _fields = new LinkedHashMap<String, JField>();
+    private final Map<String, JField> _fields = new LinkedHashMap<String, JField>();
     
     /** The list of methods of this JInterface. */
-    private Vector<JMethodSignature> _methods;
+    private final Vector<JMethodSignature> _methods = new Vector<JMethodSignature>();
 
     /**
      * Creates a new JInterface with the given name.
@@ -72,8 +72,6 @@ public final class JInterface extends JStructure {
      */
     public JInterface(final String name) {
         super(name);
-        
-        _methods = new Vector<JMethodSignature>();
 
         //-- initialize default Java doc
         getJDocComment().appendComment("Interface " + getLocalName() + ".");
@@ -83,7 +81,7 @@ public final class JInterface extends JStructure {
      * {@inheritDoc}
      */
     public void addImport(final String className) {
-        if (className == null || className.length() == 0) { return; }
+        if (className == null || className.isEmpty()) { return; }
         addImportInternal(className);
     }
 
@@ -104,7 +102,7 @@ public final class JInterface extends JStructure {
             addField((JField) jMember);
         } else {
             throw new IllegalArgumentException("invalid member for JInterface: "
-                    + jMember.toString());
+                    + jMember);
         }
     }
 
@@ -184,9 +182,7 @@ public final class JInterface extends JStructure {
      * @return An array of all the JMethodSignatures of this JInterface.
      */
     public JMethodSignature[] getMethods() {
-        JMethodSignature[] marray = new JMethodSignature[_methods.size()];
-        _methods.copyInto(marray);
-        return marray;
+        return _methods.toArray(new JMethodSignature[_methods.size()]);
     }
 
     /**
@@ -248,14 +244,14 @@ public final class JInterface extends JStructure {
             }
         }
         //-- END SORT
-        if (!added) { _methods.addElement(jMethodSig); }
+        if (!added) { _methods.add(jMethodSig); }
 
         //-- check parameter packages to make sure we have them
         //-- in our import list
 
         String[] pkgNames = jMethodSig.getParameterClassNames();
-        for (int i = 0; i < pkgNames.length; i++) {
-            addImport(pkgNames[i]);
+        for (String pkgName : pkgNames) {
+            addImport(pkgName);
         }
         //-- check return type to make sure it's included in the
         //-- import list
@@ -270,14 +266,14 @@ public final class JInterface extends JStructure {
         }
         //-- check exceptions
         JClass[] exceptions = jMethodSig.getExceptions();
-        for (int i = 0; i < exceptions.length; i++) {
-            addImport(exceptions[i].getName());
+        for (JClass exc : exceptions) {
+            addImport(exc.getName());
         }
         //-- ensure method and parameter annotations imported
         addImport(jMethodSig.getAnnotations());
         JParameter[] params = jMethodSig.getParameters();
-        for (int i = 0; i < params.length; i++) {
-            addImport(params[i].getAnnotations());
+        for (JParameter param : params) {
+            addImport(param.getAnnotations());
         }
     }
 
@@ -407,7 +403,7 @@ public final class JInterface extends JStructure {
 
         //-- print method signatures
 
-        if (_methods.size() > 0) {
+        if (!_methods.isEmpty()) {
             jsw.writeln();
             jsw.writeln("  //-----------/");
             jsw.writeln(" //- Methods -/");
@@ -415,8 +411,7 @@ public final class JInterface extends JStructure {
             jsw.writeln();
         }
 
-        for (int i = 0; i < _methods.size(); i++) {
-            JMethodSignature signature = _methods.elementAt(i);
+        for (JMethodSignature signature : _methods) {
             signature.print(jsw);
             jsw.writeln(';');
         }

--- a/codegen/src/main/java/org/exolab/javasource/JMethod.java
+++ b/codegen/src/main/java/org/exolab/javasource/JMethod.java
@@ -56,7 +56,7 @@ public final class JMethod implements JMember, JAnnotatedElement {
     //--------------------------------------------------------------------------
 
     /** The set of classes that contain this JMethod. */
-    private final Vector _classes;
+    private final Vector<JClass> _classes = new Vector<>(1);
     
     /** The JavaDoc comment for this JMethod. This will overwrite the JavaDoc for
      *  the JMethodSignature. */
@@ -80,7 +80,6 @@ public final class JMethod implements JMember, JAnnotatedElement {
             String err = "The method name must not be null or zero-length";
             throw new IllegalArgumentException(err);
         }
-        _classes = new Vector(1);
         _source = new JSourceCode();
         _signature = new JMethodSignature(name);
         _jdc = _signature.getJDocComment();
@@ -145,8 +144,8 @@ public final class JMethod implements JMember, JAnnotatedElement {
         }
         if (!jType.isPrimitive()) {
             JClass jClass = (JClass) jType;
-            for (int i = 0; i < _classes.size(); i++) {
-                ((JClass) _classes.elementAt(i)).addImport(jClass.getName());
+            for (JClass iClass : _classes) {
+                iClass.addImport(jClass.getName());
             }
         }
     }
@@ -293,7 +292,7 @@ public final class JMethod implements JMember, JAnnotatedElement {
      * @param source The String that represents the method body.
      */
     public void setSourceCode(final String source) {
-        _source = new JSourceCode(source);
+        setSourceCode(new JSourceCode(source));
     }
 
     /**

--- a/codegen/src/main/java/org/exolab/javasource/JMethodSignature.java
+++ b/codegen/src/main/java/org/exolab/javasource/JMethodSignature.java
@@ -71,10 +71,10 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
     private final Map<String, JParameter> _params = new LinkedHashMap<String, JParameter>();
     
     /** The JavaDoc comment for this method's signature. */
-    private final JDocComment _jdc;
+    private final JDocComment _jdc = new JDocComment();
     
     /** The exceptions that this method throws. */
-    private final Vector<JClass> _exceptions;
+    private final Vector<JClass> _exceptions = new Vector<>(1);
 
     /**
      * Creates a new method with the given name and "void" return type.
@@ -87,11 +87,9 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
             throw new IllegalArgumentException(err);
         }
 
-        _jdc = new JDocComment();
         _returnType = null;
         _name = name;
         _modifiers = new JModifiers();
-        _exceptions = new Vector<JClass>(1);
     }
 
     /**
@@ -120,12 +118,11 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
 
         //-- make sure exception is not already added
         String expClassName = exp.getName();
-        for (int i = 0; i < _exceptions.size(); i++) {
-            JClass jClass = _exceptions.elementAt(i);
+        for (JClass jClass : _exceptions) {
             if (expClassName.equals(jClass.getName())) { return; }
         }
         //-- add exception
-        _exceptions.addElement(exp);
+        _exceptions.add(exp);
     }
 
     /**
@@ -142,12 +139,13 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
         String pName = parameter.getName();
         //-- check current params
         if (_params.get(pName) != null) {
-            StringBuilder err = new StringBuilder(32);
-            err.append("A parameter already exists for this method, ");
-            err.append(_name);
-            err.append(", with the name: ");
-            err.append(pName);
-            throw new IllegalArgumentException(err.toString());
+            String err = new StringBuilder(96)
+                .append("A parameter already exists for this method, ")
+                .append(_name)
+                .append(", with the name: ")
+                .append(pName)
+                .toString();
+            throw new IllegalArgumentException(err);
         }
 
         _params.put(pName, parameter);
@@ -164,9 +162,7 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
      *         clause.
      */
     public JClass[] getExceptions() {
-        JClass[] jclasses = new JClass[_exceptions.size()];
-        _exceptions.copyInto(jclasses);
-        return jclasses;
+        return _exceptions.toArray(new JClass[_exceptions.size()]);
     }
 
     /**
@@ -319,8 +315,9 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
         //- Method Source -/
         //-----------------/
 
-        jsw.write(_modifiers.toString());
-        if (_modifiers.toString().length() > 0) {
+        String modifiers = _modifiers.toString();
+        jsw.write(modifiers);
+        if (!modifiers.isEmpty()) {
             jsw.write(' ');
         }
         if (_returnType != null) {
@@ -346,7 +343,7 @@ public final class JMethodSignature extends JAnnotatedElementHelper {
 
         jsw.write(")");
 
-        if (_exceptions.size() > 0) {
+        if (!_exceptions.isEmpty()) {
             jsw.write(" throws ");
             for (int i = 0; i < _exceptions.size(); i++) {
                 if (i > 0) { jsw.write(", "); }

--- a/codegen/src/main/java/org/exolab/javasource/JParameter.java
+++ b/codegen/src/main/java/org/exolab/javasource/JParameter.java
@@ -124,12 +124,12 @@ public final class JParameter extends JAnnotatedElementHelper {
      * by the name of the parameter.
      */
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("final ");
-        sb.append(_type.toString());
-        sb.append(' ');
-        sb.append(_name);
-        return sb.toString();
+        return new StringBuilder()
+            .append("final ")
+            .append(_type)
+            .append(' ')
+            .append(_name)
+            .toString();
     }
 
     //--------------------------------------------------------------------------

--- a/codegen/src/main/java/org/exolab/javasource/JSourceCode.java
+++ b/codegen/src/main/java/org/exolab/javasource/JSourceCode.java
@@ -61,7 +61,7 @@ public final class JSourceCode {
     //--------------------------------------------------------------------------
 
     /** A list of JCodeStatements. */
-    private Vector<JCodeStatement> _source = null;
+    private final Vector<JCodeStatement> _source = new Vector<>();
     
     /** The indent size. */
     private short _indentSize = DEFAULT_INDENT_SIZE;
@@ -76,8 +76,6 @@ public final class JSourceCode {
      */
     public JSourceCode() {
         super();
-        
-        _source = new Vector<JCodeStatement>();
     }
 
     /**
@@ -88,7 +86,7 @@ public final class JSourceCode {
     public JSourceCode(final String sourceCode) {
         this();
         
-        _source.addElement(new JCodeStatement(sourceCode, _currentIndent));
+        _source.add(new JCodeStatement(sourceCode, _currentIndent));
     }
 
     //--------------------------------------------------------------------------
@@ -157,7 +155,7 @@ public final class JSourceCode {
      * @param statement The statement to add.
      */
     public void add(final String statement) {
-        _source.addElement(new JCodeStatement(statement, _currentIndent));
+        _source.add(new JCodeStatement(statement, _currentIndent));
     }
 
     /**
@@ -173,7 +171,7 @@ public final class JSourceCode {
      */
     public void addIndented(final String statement) {
         indent();
-        _source.addElement(new JCodeStatement(statement, _currentIndent));
+        _source.add(new JCodeStatement(statement, _currentIndent));
         unindent();
     }
 
@@ -204,8 +202,8 @@ public final class JSourceCode {
      * @param jsc The JSourceCode to copy this JSourceCode into.
      */
     public void copyInto(final JSourceCode jsc) {
-        for (int i = 0; i < _source.size(); i++) {
-             jsc.addCodeStatement(_source.elementAt(i));
+        for (JCodeStatement jcs : _source) {
+             jsc.addCodeStatement(jcs);
         }
     }
 
@@ -231,8 +229,8 @@ public final class JSourceCode {
      * @param jsw The JSourceWriter to print to.
      */
     public void print(final JSourceWriter jsw) {
-        for (int i = 0; i < _source.size(); i++) {
-            jsw.writeln(_source.elementAt(i).toString());
+        for (JCodeStatement jcs : _source) {
+            jsw.writeln(jcs.toString());
         }
     }
 
@@ -259,7 +257,7 @@ public final class JSourceCode {
      */
     private void addCodeStatement(final JCodeStatement jcs) {
         short indent = (short) (jcs.getIndent() + _currentIndent - DEFAULT_INDENT_SIZE);
-        _source.addElement(new JCodeStatement(jcs.getStatement(), indent));
+        _source.add(new JCodeStatement(jcs.getStatement(), indent));
     }
     
     /**
@@ -279,9 +277,8 @@ public final class JSourceCode {
     public String toString() {
         StringBuilder sb = new StringBuilder(100);
         String lineSeparator = System.getProperty("line.separator");
-        for (int i = 0; i < _source.size(); i++) {
-            sb.append(_source.elementAt(i).toString());
-            sb.append(lineSeparator);
+        for (JCodeStatement jcs : _source) {
+            sb.append(jcs).append(lineSeparator);
         }
         return sb.toString();
     }

--- a/codegen/src/main/java/org/exolab/javasource/JStructure.java
+++ b/codegen/src/main/java/org/exolab/javasource/JStructure.java
@@ -78,28 +78,28 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
     private static final String JSW_SHOULD_NOT_BE_NULL = "argument 'jsw' should not be null.";
 
     /** The source header. */
-    private JComment _header;
+    private JComment _header = null;
 
     /** The package to which this JStructure belongs. */
-    private String _packageName;
+    private final String _packageName;
 
     /** List of imported classes and packages. */
-    private Vector<String> _imports;
+    private final Vector<String> _imports = new Vector<>();
 
     /** The Javadoc for this JStructure. */
-    private JDocComment _jdc;
+    private final JDocComment _jdc = new JDocComment(JDocDescriptor.createVersionDesc(DEFAULT_VERSION));
 
     /** Implementation of JAnnoatedElement to delagate to. */
-    private JAnnotatedElementHelper _annotatedElement;
+    private final JAnnotatedElementHelper _annotatedElement = new JAnnotatedElementHelper();
 
     /**
      * The JModifiers for this JStructure, which allows us to change the
      * resulting qualifiers.
      */
-    private JModifiers _modifiers;
+    private final JModifiers _modifiers = new JModifiers();
 
     /** The set of interfaces implemented/extended by this JStructure. */
-    private Vector<String> _interfaces;
+    private final Vector<String> _interfaces = new Vector<>();
 
     /**
      * Creates a new JStructure with the given name.
@@ -122,13 +122,7 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
             throw new IllegalArgumentException(err);
         }
 
-        _header = null;
         _packageName = JNaming.getPackageFromClassName(name);
-        _imports = new Vector<String>();
-        _jdc = new JDocComment(JDocDescriptor.createVersionDesc(DEFAULT_VERSION));
-        _annotatedElement = new JAnnotatedElementHelper();
-        _modifiers = new JModifiers();
-        _interfaces = new Vector<String>();
     }
 
     /**
@@ -255,7 +249,7 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
                     return;
                 }
             }
-            _imports.addElement(className);
+            _imports.add(className);
         }
     }
 
@@ -278,8 +272,8 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
      *            JStructure for each JAnnotation in the Array.
      */
     protected final void addImport(final JAnnotation[] annotations) {
-        for (int i = 0; i < annotations.length; i++) {
-            addImport(annotations[i].getAnnotationType().getName());
+        for (JAnnotation annotation : annotations) {
+            addImport(annotation.getAnnotationType().getName());
         }
     }
 
@@ -294,14 +288,9 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
      */
     public final boolean removeImport(final String className) {
         boolean result = false;
-        if (className == null) {
-            return result;
+        if (className != null && !className.isEmpty()) {
+            result = _imports.remove(className);
         }
-        if (className.length() == 0) {
-            return result;
-        }
-
-        result = _imports.removeElement(className);
         return result;
     }
 
@@ -410,7 +399,7 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
      */
     public final void addInterface(final String interfaceName) {
         if (!_interfaces.contains(interfaceName)) {
-            _interfaces.addElement(interfaceName);
+            _interfaces.add(interfaceName);
         }
     }
 
@@ -495,8 +484,9 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
         }
 
         // -- Prefix filename with path
-        if (pathFile.toString().length() > 0) {
-            filename = pathFile.toString() + File.separator + filename;
+        final String pathStr = pathFile.toString();
+        if (!pathStr.isEmpty()) {
+            filename = pathStr + File.separator + filename;
         }
 
         return filename;
@@ -600,7 +590,7 @@ public abstract class JStructure extends JType implements JAnnotatedElement {
         }
 
         // -- print imports
-        if (_imports.size() > 0) {
+        if (!_imports.isEmpty()) {
             jsw.writeln("  //---------------------------------/");
             jsw.writeln(" //- Imported classes and packages -/");
             jsw.writeln("//---------------------------------/");

--- a/core/src/main/java/org/castor/core/util/CycleBreaker.java
+++ b/core/src/main/java/org/castor/core/util/CycleBreaker.java
@@ -120,7 +120,7 @@ public class CycleBreaker {
                 hthr.remove(beingHashed); 
 
                 // release any references if we have no more CycleHandles
-                if (hthr.size() == 0) {
+                if (hthr.isEmpty()) {
 
                     // before removing the threads empty hash from _threadHash
                     // acquire write lock first

--- a/diff/src/main/java/org/castor/xmlctf/xmldiff/xml/XMLFileReader.java
+++ b/diff/src/main/java/org/castor/xmlctf/xmldiff/xml/XMLFileReader.java
@@ -119,14 +119,15 @@ public class XMLFileReader {
                 throw new NestedIOException(sx);
             }
 
-            StringBuffer err = new StringBuffer(sxp.toString());
-            err.append("\n - ");
-            err.append(sxp.getSystemId());
-            err.append("; line: ");
-            err.append(sxp.getLineNumber());
-            err.append(", column: ");
-            err.append(sxp.getColumnNumber());
-            throw new NestedIOException(err.toString(), sx);
+            String err = new StringBuilder(sxp.toString())
+                .append("\n - ")
+                .append(sxp.getSystemId())
+                .append("; line: ")
+                .append(sxp.getLineNumber())
+                .append(", column: ")
+                .append(sxp.getColumnNumber())
+                .toString();
+            throw new NestedIOException(err, sx);
         }
 
         Root root = (Root) node;

--- a/examples/src/main/java/myapp/Category.java
+++ b/examples/src/main/java/myapp/Category.java
@@ -7,7 +7,7 @@ public class Category
 {
     private int      _id;
 
-    private Vector   _products = new Vector();
+    private final Vector<Product> _products = new Vector<>();
 
     private String   _name;
 
@@ -48,7 +48,7 @@ public class Category
     {
         if ( ! _products.contains( product ) ) {
             System.out.println( "Adding product " + product + " to category " + this );
-            _products.addElement( product );
+            _products.add( product );
             product.addCategories( this );
         }
     }

--- a/examples/src/main/java/myapp/Product.java
+++ b/examples/src/main/java/myapp/Product.java
@@ -17,9 +17,9 @@ public class Product implements Persistent, TimeStampable {
 
     private long _timeStamp;
 
-    private Vector _details = new Vector();
+    private final Vector<ProductDetail> _details = new Vector<>();
 
-    private Vector _categories = new Vector();
+    private final Vector<Category> _categories = new Vector<>();
 
     public int getId() {
         return _id;
@@ -72,7 +72,7 @@ public class Product implements Persistent, TimeStampable {
 
     public void addCategories(final Category category) {
         if (!_categories.contains(category)) {
-            _categories.addElement(category);
+            _categories.add(category);
             category.addProduct(this);
         }
     }

--- a/schema/src/main/java/org/exolab/castor/xml/schema/Annotated.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/Annotated.java
@@ -59,14 +59,14 @@ public abstract class Annotated extends Structure {
     /**
      * The Annotations of this Annotated structure.
     **/
-    private Vector<Annotation> _annotations = new Vector<Annotation>(1);
+    private final Vector<Annotation> _annotations = new Vector<Annotation>(1);
     
    /**
      * Adds the given Annotation to this Annotated Structure.
      * @param annotation the Annotation to add
     **/
     public void addAnnotation(final Annotation annotation) {
-        _annotations.addElement(annotation);
+        _annotations.add(annotation);
     }
     
     /**
@@ -84,7 +84,7 @@ public abstract class Annotated extends Structure {
      * @param annotation the Annotation to remove
     **/
     public void removeAnnotation(final Annotation annotation) {
-        _annotations.removeElement(annotation);
+        _annotations.remove(annotation);
     }
     
 }

--- a/schema/src/main/java/org/exolab/castor/xml/schema/Annotation.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/Annotation.java
@@ -62,12 +62,12 @@ public class Annotation extends Structure {
     /**
      * List of {@literal <appinfo/>} objects.
     **/
-    private Vector<AppInfo> _appInfos = new Vector<AppInfo>();
+    private final Vector<AppInfo> _appInfos = new Vector<>();
     
     /**
      * List of <documentation/> objects.
     **/
-    private Vector<Documentation> _documentations = new Vector<Documentation>();
+    private final Vector<Documentation> _documentations = new Vector<>();
     
     /**
      * Adds the given {@link AppInfo} to this annotation.
@@ -75,7 +75,7 @@ public class Annotation extends Structure {
     **/
     public void addAppInfo(final AppInfo appInfo) {
         if (appInfo != null) {
-            _appInfos.addElement(appInfo);
+            _appInfos.add(appInfo);
         }
     }
     
@@ -85,7 +85,7 @@ public class Annotation extends Structure {
     **/
     public void addDocumentation(final Documentation documentation) {
         if (documentation != null) {
-            _documentations.addElement(documentation);
+            _documentations.add(documentation);
         }
     }
 
@@ -111,7 +111,7 @@ public class Annotation extends Structure {
     **/
     public void removeAppInfo(final AppInfo appInfo) {
         if (appInfo != null) {
-            _appInfos.removeElement(appInfo);
+            _appInfos.remove(appInfo);
         }
     }
 
@@ -121,7 +121,7 @@ public class Annotation extends Structure {
     **/
     public void removeDocumentation(final Documentation documentation) {
         if (documentation != null) {
-            _documentations.removeElement(documentation);
+            _documentations.remove(documentation);
         }
     }
     

--- a/schema/src/main/java/org/exolab/castor/xml/schema/AnnotationItem.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/AnnotationItem.java
@@ -78,7 +78,7 @@ public abstract class AnnotationItem extends Structure {
      */
     public void add(Object object) {
         if (object != null)
-            _objects.addElement(object);
+            _objects.add(object);
     } //-- add
     
     /**
@@ -126,7 +126,7 @@ public abstract class AnnotationItem extends Structure {
      * @param object the Object to remove
      */
     public void remove(Object object) {
-        if (object != null) _objects.removeElement(object);
+        if (object != null) _objects.remove(object);
     } //-- remove
 
     /**

--- a/schema/src/main/java/org/exolab/castor/xml/schema/AttributeGroupDecl.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/AttributeGroupDecl.java
@@ -126,7 +126,7 @@ public final class AttributeGroupDecl extends AttributeGroup {
         //-- add validation code
 
         //-- add to internal collection
-        _attributes.addElement(attrDecl);
+        _attributes.add(attrDecl);
         //--set the parent
         attrDecl.setParent(this);
 
@@ -144,7 +144,7 @@ public final class AttributeGroupDecl extends AttributeGroup {
         //-- add validation code
 
         //-- add to internal collection
-        _references.addElement(attrGroup);
+        _references.add(attrGroup);
 
     } //-- addReference
 
@@ -234,12 +234,12 @@ public final class AttributeGroupDecl extends AttributeGroup {
     **/
     public boolean isEmpty() {
 
-        if (_attributes.size() > 0) return false;
+        if (!_attributes.isEmpty()) return false;
 
         if (_references.isEmpty()) return true;
 
-        for (int i = 0; i < _references.size(); i++) {
-            if (!((AttributeGroup)_references.elementAt(i)).isEmpty())
+        for (AttributeGroup attributeGroup : _references) {
+            if (!attributeGroup.isEmpty())
                 return false;
         }
         return true;
@@ -261,11 +261,7 @@ public final class AttributeGroupDecl extends AttributeGroup {
     **/
     public boolean removeAttribute(AttributeDecl attr) {
         if (attr == null )   return false;
-        if (_attributes.contains(attr)) {
-            _attributes.removeElement(attr);
-            return true;
-        }
-        return false;
+        return _attributes.remove(attr);
     } //-- removeAttribute
 
     /**
@@ -274,11 +270,7 @@ public final class AttributeGroupDecl extends AttributeGroup {
     **/
     public boolean removeReference(AttributeGroupReference attrGroupReference) {
          if (attrGroupReference == null ) return false;
-         if (_references.contains(attrGroupReference)) {
-            _references.removeElement(attrGroupReference);
-            return true;
-         }
-         return false;
+         return _references.remove(attrGroupReference);
     } //-- removeReference
 
     /**

--- a/schema/src/main/java/org/exolab/castor/xml/schema/ContentModelGroupImpl.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/ContentModelGroupImpl.java
@@ -62,7 +62,7 @@ class ContentModelGroupImpl implements ContentModelGroup , java.io.Serializable 
     /**
      * Collection holding all {@link Particle}s of this content model group.
      */
-    private Vector<Particle> _contentModel = new Vector<Particle>();
+    private final Vector<Particle> _contentModel = new Vector<>();
     
     private transient ScopableResolver _resolver = new ScopableResolver();
 
@@ -75,7 +75,7 @@ class ContentModelGroupImpl implements ContentModelGroup , java.io.Serializable 
         if (wildcard.isAttributeWildcard()) {
             throw new SchemaException("only <any> should be add in a group.");
         }
-        _contentModel.addElement(wildcard);
+        _contentModel.add(wildcard);
     }
 
     /**
@@ -104,7 +104,7 @@ class ContentModelGroupImpl implements ContentModelGroup , java.io.Serializable 
         }
 
         //-- add to content model
-        _contentModel.addElement(elementDecl);
+        _contentModel.add(elementDecl);
 
     }
 
@@ -153,7 +153,7 @@ class ContentModelGroupImpl implements ContentModelGroup , java.io.Serializable 
         }
 
         // -- add to content model
-        _contentModel.addElement(group);
+        _contentModel.add(group);
     }
 
     /**
@@ -202,7 +202,7 @@ class ContentModelGroupImpl implements ContentModelGroup , java.io.Serializable 
         }
 
         // -- add to content model
-        _contentModel.addElement(group);
+        _contentModel.add(group);
     }
 
     /**
@@ -272,8 +272,7 @@ class ContentModelGroupImpl implements ContentModelGroup , java.io.Serializable 
                 return result;
             }
         }
-        for (int i = 0; i < _contentModel.size(); i++) {
-            Particle particle = _contentModel.elementAt(i);
+        for (Particle particle : _contentModel) {
             switch (particle.getStructureType()) {
             case Structure.ELEMENT:
                 ElementDecl e = (ElementDecl) particle;

--- a/schema/src/main/java/org/exolab/castor/xml/schema/ElementDecl.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/ElementDecl.java
@@ -196,7 +196,7 @@ public class ElementDecl extends Particle implements Referable {
     **/
     public void addIdentityConstraint(IdentityConstraint constraint) {
         if (constraint == null) return;
-        _constraints.addElement(constraint);
+        _constraints.add(constraint);
     } //-- addIdentityConstraint
 
 	/**
@@ -541,7 +541,7 @@ public class ElementDecl extends Particle implements Referable {
     public boolean removeIdentityConstraint(IdentityConstraint constraint)
     {
         if (constraint ==  null) return false;
-        return _constraints.removeElement(constraint);
+        return _constraints.remove(constraint);
     } //-- removeIdentityConstraint
 
 

--- a/schema/src/main/java/org/exolab/castor/xml/schema/IdentityConstraint.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/IdentityConstraint.java
@@ -100,7 +100,7 @@ public abstract class IdentityConstraint extends Annotated {
     **/
     public void addField(IdentityField field) {
         if (field != null)
-            _fields.addElement(field);
+            _fields.add(field);
     } //-- addField
     
     /**
@@ -151,7 +151,7 @@ public abstract class IdentityConstraint extends Annotated {
      * IdentityConstraint, otherwise false.
     **/
     public boolean removeField(IdentityField field) {
-        return _fields.removeElement(field);
+        return _fields.remove(field);
     } //-- removeField
     
      

--- a/schema/src/main/java/org/exolab/castor/xml/schema/ModelGroup.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/ModelGroup.java
@@ -114,7 +114,7 @@ public class ModelGroup extends Group {
     **/
     public void addModelGroup(ModelGroup modelGroup) {
         if (!_modelDefs.contains(modelGroup)) {
-            _modelDefs.addElement(modelGroup);
+            _modelDefs.add(modelGroup);
         }
     } //-- addModelGroup
 

--- a/schema/src/main/java/org/exolab/castor/xml/schema/Schema.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/Schema.java
@@ -48,6 +48,7 @@ package org.exolab.castor.xml.schema;
 import org.exolab.castor.xml.Namespaces;
 import org.exolab.castor.xml.ValidationException;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -123,12 +124,12 @@ public class Schema extends Annotated {
     /**
      * The global AttribteGroups for this Schema
     **/
-    private Map<String, AttributeGroup> _attributeGroups = new Hashtable<String, AttributeGroup>();
+    private final Map<String, AttributeGroup> _attributeGroups = new Hashtable<String, AttributeGroup>();
 
     /**
      * The global attributes for this Schema
     **/
-    private Map<String, AttributeDecl> _attributes = new Hashtable<String, AttributeDecl>();
+    private final Map<String, AttributeDecl> _attributes = new Hashtable<String, AttributeDecl>();
 
     /**
      * The value of the block attribute.
@@ -139,7 +140,7 @@ public class Schema extends Annotated {
     /**
      * A list of defined architypes
     **/
-    private Map<String, ComplexType> _complexTypes = new Hashtable<String, ComplexType>();
+    private final Map<String, ComplexType> _complexTypes = new Hashtable<String, ComplexType>();
 
     /**
      * The elementFormDefault attribute for this Schema
@@ -149,7 +150,7 @@ public class Schema extends Annotated {
     /**
      * A list of defined elements
     **/
-    private Map<String, ElementDecl> _elements = new Hashtable<String, ElementDecl>();
+    private final Map<String, ElementDecl> _elements = new Hashtable<String, ElementDecl>();
 
     /**
      * The value of the final attribute.
@@ -159,12 +160,12 @@ public class Schema extends Annotated {
     /**
      * A list of defined top-levels groups
      */
-    private Map<String, ModelGroup> _groups = new Hashtable<String, ModelGroup>();
+    private final Map<String, ModelGroup> _groups = new Hashtable<String, ModelGroup>();
     
     /**
      * A list of defined <redefine>
      */
-    private Map<String, RedefineSchema> _redefineSchemas = new Hashtable<String, RedefineSchema>();
+    private final Map<String, RedefineSchema> _redefineSchemas = new Hashtable<String, RedefineSchema>();
 
     /**
      * The ID for this Schema
@@ -174,24 +175,24 @@ public class Schema extends Annotated {
     /**
      * A list of imported schemas
     **/
-    private Map<String, Schema> _importedSchemas = new Hashtable<String, Schema>();
+    private final Map<String, Schema> _importedSchemas = new Hashtable<String, Schema>();
     
     /**
      * A list of included schemas meant to be used only 
      * when the cache mechanism is enabled.
      **/
-    private Map<String, Schema> _cachedincludedSchemas = new Hashtable<String, Schema>();
+    private final Map<String, Schema> _cachedincludedSchemas = new Hashtable<String, Schema>();
     
 
     /**
      * A list of XML Schema files included in this schema
     **/
-    private Vector<String> _includedSchemas = new Vector<String>();
+    private final Vector<String> _includedSchemas = new Vector<String>();
 
     /**
      * A list of namespaces declared in this schema
      */
-    private Namespaces _namespaces = new Namespaces();
+    private final Namespaces _namespaces = new Namespaces();
 
     /**
      * The schemaLocation hint provided in the 'import' tag.
@@ -203,13 +204,13 @@ public class Schema extends Annotated {
      * The namespace of this XML Schema (ie the namespace
      * of the W3C Schema supported by this Schema).
     **/
-    private String _schemaNamespace = null;
+    private final String _schemaNamespace;
 
 
     /**
      * A list of defined SimpleTypes
     **/
-    private Hashtable<String, SimpleType> _simpleTypes = new Hashtable<String, SimpleType>();
+    private final Hashtable<String, SimpleType> _simpleTypes = new Hashtable<String, SimpleType>();
 
     /**
      * The targetNamespace for this Schema
@@ -645,7 +646,7 @@ public class Schema extends Annotated {
      * @return an Enumeration of all top-level Attribute declarations
     **/
     public Collection<AttributeDecl> getAttributes() {
-    	Vector<AttributeDecl> result = new Vector<AttributeDecl>(_attributes.size()*2);
+    	Collection<AttributeDecl> result = new ArrayList<>(_attributes.size()*2);
     	
     	result.addAll(_attributes.values());
     
@@ -686,8 +687,8 @@ public class Schema extends Annotated {
 
         //-- Null?
         if (name == null)  {
-            String err = NULL_ARGUMENT + "getAttribute: ";
-            err += "'name' cannot be null.";
+            String err = NULL_ARGUMENT + "getAttribute: "
+                + "'name' cannot be null.";
             throw new IllegalArgumentException(err);
         }
 
@@ -702,8 +703,8 @@ public class Schema extends Annotated {
             nsprefix = name.substring(0,colon);
             ns = _namespaces.getNamespaceURI(nsprefix);
             if (ns == null)  {
-                String err = "getAttribute: ";
-                err += "Namespace prefix not recognized '"+name+"'";
+                String err = "getAttribute: "
+                    + "Namespace prefix not recognized '"+name+"'";
                 throw new IllegalArgumentException(err);
             }
         }
@@ -763,7 +764,7 @@ public class Schema extends Annotated {
      * @return an Enumeration of all top-level AttributeGroup declarations
     **/
     public Collection<AttributeGroup> getAttributeGroups() {
-    	Vector<AttributeGroup> result = new Vector<AttributeGroup>(_attributeGroups.size()*2);
+    	Collection<AttributeGroup> result = new ArrayList<>(_attributeGroups.size()*2);
     	
     	result.addAll(_attributeGroups.values());
     	
@@ -996,7 +997,7 @@ public class Schema extends Annotated {
      * @return an Enumeration of all top-level ComplexType declarations
     **/
     public Collection<ComplexType> getComplexTypes() {
-    	Vector<ComplexType> result = new Vector<ComplexType>(_complexTypes.size()*2);
+    	Collection<ComplexType> result = new ArrayList<>(_complexTypes.size()*2);
     	
     	result.addAll(_complexTypes.values());
     	
@@ -1107,7 +1108,7 @@ public class Schema extends Annotated {
      * @return an Enumeration of all top-level element declarations
     **/
     public Collection<ElementDecl> getElementDecls() {
-    	Vector<ElementDecl> result = new Vector<ElementDecl>(_elements.size()*2);
+    	Collection<ElementDecl> result = new ArrayList<>(_elements.size()*2);
     	
     	result.addAll(_elements.values());
     	
@@ -1350,7 +1351,7 @@ public class Schema extends Annotated {
                 }
             }
         }
-        Vector<SimpleType> result = new Vector<SimpleType>(_simpleTypes.size()*2);
+        Collection<SimpleType> result = new ArrayList<>(_simpleTypes.size()*2);
         
         result.addAll(_simpleTypes.values());
         
@@ -1477,7 +1478,7 @@ public class Schema extends Annotated {
      * @return an Enumeration of all top-level ModelGroup declarations
     **/
     public Collection<ModelGroup> getModelGroups() {
-    	Vector<ModelGroup> result = new Vector<ModelGroup>(_groups.size()*2);
+    	Collection<ModelGroup> result = new ArrayList<>(_groups.size()*2);
     	
     	result.addAll(_groups.values());
    	
@@ -1568,7 +1569,7 @@ public class Schema extends Annotated {
      * @return the cached included XML schema
      */
     public Schema getCachedIncludedSchema(String schemaLocation) {
-    		return _cachedincludedSchemas.get(schemaLocation);
+        return _cachedincludedSchemas.get(schemaLocation);
     } //-- getCachedIncludedSchema
     
     /**
@@ -1657,7 +1658,7 @@ public class Schema extends Annotated {
      */
     public void addInclude(String include)
     {
-        _includedSchemas.addElement(include);
+        _includedSchemas.add(include);
     } //-- addInclude
 
     /**

--- a/schema/src/main/java/org/exolab/castor/xml/schema/Wildcard.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/Wildcard.java
@@ -139,7 +139,7 @@ public class Wildcard extends Particle {
      * @param Namespace the namespace to add
      */
      public void addNamespace(String Namespace) {
-         _namespaces.addElement(Namespace);
+         _namespaces.add(Namespace);
      }
 
    /**

--- a/schema/src/main/java/org/exolab/castor/xml/schema/reader/ComponentReader.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/reader/ComponentReader.java
@@ -274,12 +274,13 @@ public abstract class ComponentReader {
     * This method is called when an out of order element is encountered
     **/
    public void outOfOrder(String name) throws XMLException {
-      StringBuffer err = new StringBuffer("out of order element <");
-      err.append(name);
-      err.append("> found in <");
-      err.append(elementName());
-      err.append(">.");
-      throw new XMLException(err.toString());
+      String err = new StringBuilder("out of order element <")
+          .append(name)
+          .append("> found in <")
+          .append(elementName())
+          .append(">.")
+          .toString();
+      throw new XMLException(err);
    }
 
    /**

--- a/schema/src/main/java/org/exolab/castor/xml/schema/reader/WildcardUnmarshaller.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/reader/WildcardUnmarshaller.java
@@ -289,12 +289,13 @@ public class WildcardUnmarshaller extends ComponentReader {
         }
 
         else {
-            StringBuffer err = new StringBuffer("illegal element <");
-            err.append(name);
-            err.append("> found in <");
-            err.append(_element);
-            err.append(">");
-            throw new SchemaException(err.toString());
+            String err = new StringBuffer("illegal element <")
+                .append(name)
+                .append("> found in <")
+                .append(_element)
+                .append('>')
+                .toString();
+            throw new SchemaException(err);
         }
 
     } //-- startElement

--- a/schema/src/main/java/org/exolab/castor/xml/schema/simpletypes/factory/Type.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/simpletypes/factory/Type.java
@@ -154,18 +154,17 @@ public class Type
      * @see java.lang.Object#toString()
      */
     public String toString() {
-        StringBuffer sb = new StringBuffer();
-        sb.append("name: ").append(name);
-        sb.append(" code: ").append(code);
-        sb.append(" base: ").append(base);
-        sb.append(" impl: ").append(impl);
-        sb.append(" derivedBy: ").append(derivedBy);
-        sb.append('\n');
-        sb.append("Facets count: ").append(facet.size());
-        sb.append('\n');
-        for (int index = 0; index < facet.size(); index++) {
-            TypeProperty tp = (TypeProperty) (facet.elementAt(index));
-            sb.append(tp.toString());
+        StringBuilder sb = new StringBuilder()
+            .append("name: ").append(name)
+            .append(" code: ").append(code)
+            .append(" base: ").append(base)
+            .append(" impl: ").append(impl)
+            .append(" derivedBy: ").append(derivedBy)
+            .append('\n')
+            .append("Facets count: ").append(facet.size())
+            .append('\n');
+        for (TypeProperty tp : facet) {
+            sb.append(tp);
         }
         sb.append('\n');
         return sb.toString();

--- a/schema/src/main/java/org/exolab/castor/xml/schema/simpletypes/factory/TypeList.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/simpletypes/factory/TypeList.java
@@ -77,9 +77,8 @@ public class TypeList
     {
         output.println("Types count: " + types.size());
 
-        for( int index= 0; index < types.size(); index++)
-        {
-            ((Type)(types.elementAt(index))).Print(output);
+        for (Type t : types) {
+            t.Print(output);
         }
         output.println();
         output.flush();
@@ -90,8 +89,8 @@ public class TypeList
      * @see java.lang.Object#toString()
      */
     public String toString() {
-        StringBuilder sb = new StringBuilder()
-            .append("Types count: ").append(types.size());
+        StringBuilder sb = new StringBuilder("Types count: ")
+            .append(types.size());
         for (Type t : types) {
             sb.append(t);
         }

--- a/schema/src/main/java/org/exolab/castor/xml/schema/util/XMLInstance2SchemaHandler.java
+++ b/schema/src/main/java/org/exolab/castor/xml/schema/util/XMLInstance2SchemaHandler.java
@@ -219,7 +219,7 @@ public final class XMLInstance2SchemaHandler
                 DatatypeHandler.guessType(sInfo.buffer.toString());
             sInfo.element.setTypeReference(typeName);
             //-- simpleContent
-            if (sInfo.attributes.size() > 0) {
+            if (!sInfo.attributes.isEmpty()) {
                 ComplexType cType = new ComplexType(_schema);
                 //-- SHOULD CHANGE THIS TO SIMPLE CONTENT WHEN
                 //-- SCHEMA WRITER BUGS ARE FIXED
@@ -230,9 +230,7 @@ public final class XMLInstance2SchemaHandler
                 //-- add attributes
                 try {
                     cType.addGroup(group);
-                    for (int i = 0; i < sInfo.attributes.size(); i++) {
-                        AttributeDecl attDecl = 
-                            (AttributeDecl)sInfo.attributes.elementAt(i);
+                    for (AttributeDecl attDecl : sInfo.attributes) {
                         cType.addAttributeDecl(attDecl);
                     }
                 }
@@ -244,7 +242,7 @@ public final class XMLInstance2SchemaHandler
         else {
             ComplexType cType = (ComplexType)sInfo.element.getType();
             
-            if ((cType == null) && (sInfo.attributes.size() > 0)) {
+            if (cType == null && !sInfo.attributes.isEmpty()) {
                 cType = new ComplexType(_schema);
                 sInfo.element.setType(cType);
                 Group group = new Group();
@@ -259,9 +257,7 @@ public final class XMLInstance2SchemaHandler
             }
             
             if (cType != null) {
-                for (int i = 0; i < sInfo.attributes.size(); i++) {
-                    AttributeDecl attDecl = 
-                        (AttributeDecl)sInfo.attributes.elementAt(i);
+                for (AttributeDecl attDecl : sInfo.attributes) {
                     cType.addAttributeDecl(attDecl);
                 }
             }
@@ -435,7 +431,7 @@ public final class XMLInstance2SchemaHandler
                 
             attr.setSimpleTypeReference(typeName);
             
-            sInfo.attributes.addElement(attr);
+            sInfo.attributes.add(attr);
         }
         
     } //-- startElement

--- a/xml/src/main/java/org/exolab/castor/dsml/SearchDescriptor.java
+++ b/xml/src/main/java/org/exolab/castor/dsml/SearchDescriptor.java
@@ -46,8 +46,9 @@
 package org.exolab.castor.dsml;
 
 import java.io.Serializable;
-import java.util.Vector;
 import java.util.Enumeration;
+import java.util.Collections;
+import java.util.Vector;
 import org.xml.sax.DocumentHandler;
 import org.xml.sax.AttributeList;
 import org.xml.sax.SAXException;
@@ -94,7 +95,7 @@ public class SearchDescriptor extends HandlerBase implements Serializable {
 
     private String _filter;
 
-    private Vector _returnAttrs;
+    private Vector<String> _returnAttrs;
 
     private StringBuffer _attrName;
 
@@ -129,31 +130,26 @@ public class SearchDescriptor extends HandlerBase implements Serializable {
 
     public String[] getReturnAttrs() {
         if (_returnAttrs == null) { return null; }
-        String[] array = new String[_returnAttrs.size()];
-        _returnAttrs.copyInto(array);
-        return array;
+        return _returnAttrs.toArray(new String[_returnAttrs.size()]);
     }
 
-    public Enumeration listReturnAttrs() {
-        if (_returnAttrs == null) { return new Vector().elements(); }
+    public Enumeration<String> listReturnAttrs() {
+        if (_returnAttrs == null) { return Collections.emptyEnumeration(); }
         return _returnAttrs.elements();
     }
 
     public void addReturnAttr(final String attrName) {
         if (_returnAttrs == null) {
-            _returnAttrs = new Vector();
+            _returnAttrs = new Vector<>();
         }
         if (!_returnAttrs.contains(attrName)) {
-            _returnAttrs.addElement(attrName);
+            _returnAttrs.add(attrName);
         }
     }
 
 
     public void produce(final DocumentHandler docHandler) throws SAXException {
-        AttributeListImpl attrList;
-        Enumeration       enumeration;
-
-        attrList = new AttributeListImpl();
+        AttributeListImpl attrList = new AttributeListImpl();
         docHandler.startElement(XML.Namespace.ROOT, attrList);
 
         attrList = new AttributeListImpl();
@@ -180,11 +176,11 @@ public class SearchDescriptor extends HandlerBase implements Serializable {
         docHandler.startElement(Names.Element.SEARCH, attrList);
 
         if (_returnAttrs != null) {
-            enumeration = _returnAttrs.elements();
+            Enumeration<String> enumeration = _returnAttrs.elements();
             while (enumeration.hasMoreElements()) {
                 attrList = new AttributeListImpl();
                 attrList.addAttribute(Names.Attribute.ATTRIBUTE_NAME, "NMTOKEN",
-                        (String) enumeration.nextElement());
+                        enumeration.nextElement());
                 docHandler.startElement(Names.Element.RETURN_ATTRIBUTE, attrList);
                 docHandler.endElement(Names.Element.RETURN_ATTRIBUTE);
             }

--- a/xml/src/main/java/org/exolab/castor/dsml/jndi/JNDIEntryConsumer.java
+++ b/xml/src/main/java/org/exolab/castor/dsml/jndi/JNDIEntryConsumer.java
@@ -70,7 +70,7 @@ class JNDIEntryConsumer extends HandlerBase {
     private Attribute _attr;
     private StringBuffer _value;
     private Base64Decoder _decoder;
-    private Vector<SearchResult> _entries = new Vector<SearchResult>();
+    private final Vector<SearchResult> _entries = new Vector<>();
 
     JNDIEntryConsumer() {
     }
@@ -123,7 +123,7 @@ class JNDIEntryConsumer extends HandlerBase {
             if (_attrSet == null || _attr != null) {
                 throw new SAXException(Messages.format("dsml.closingTagNotRecognized", tagName));
             }
-            _entries.addElement(new SearchResult(_entryDN, null, _attrSet));
+            _entries.add(new SearchResult(_entryDN, null, _attrSet));
             _entryDN = null;
             _attrSet = null;
         } else if (tagName.equals(XML.Entries.Elements.OBJECT_CLASS)

--- a/xml/src/main/java/org/exolab/castor/dsml/jndi/JNDIImporter.java
+++ b/xml/src/main/java/org/exolab/castor/dsml/jndi/JNDIImporter.java
@@ -45,8 +45,9 @@
 
 package org.exolab.castor.dsml.jndi;
 
-import java.util.Vector;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import javax.naming.NamingException;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
@@ -99,7 +100,7 @@ public class JNDIImporter extends Importer {
             try {
                 existing = _ctx.getAttributes(result.getName());
 
-                Vector<ModificationItem> modifs = new Vector<ModificationItem>();
+                List<ModificationItem> modifs = new ArrayList<ModificationItem>();
                 attrSet = result.getAttributes();
                 enumeration = attrSet.getAll();
                 while (enumeration.hasMore()) {
@@ -107,17 +108,17 @@ public class JNDIImporter extends Importer {
                     if (existing.get(attr.getID()) != null) {
                         if ((policy & ImportDescriptor.Policy.NEW_ATTRIBUTE_ONLY) == 0) {
                             if (attr.size() > 0) {
-                                modifs.addElement(new ModificationItem(
+                                modifs.add(new ModificationItem(
                                         DirContext.REPLACE_ATTRIBUTE, attr));
                             } else {
-                                modifs.addElement(new ModificationItem(
+                                modifs.add(new ModificationItem(
                                         DirContext.REMOVE_ATTRIBUTE, attr));
                             }
                         }
                     } else {
                         if ((policy & ImportDescriptor.Policy.UPDATE_ONLY) == 0) {
                             if (attr.size() > 0) {
-                                modifs.addElement(new ModificationItem(
+                                modifs.add(new ModificationItem(
                                         DirContext.ADD_ATTRIBUTE, attr));
                             }
                         }
@@ -128,16 +129,13 @@ public class JNDIImporter extends Importer {
                     while (enumeration.hasMore()) {
                         attr = enumeration.next();
                         if (attrSet.get(attr.getID()) == null) {
-                            modifs.addElement(new ModificationItem(
+                            modifs.add(new ModificationItem(
                                     DirContext.REMOVE_ATTRIBUTE, attr));
                         }
                     }
                 }
-                if (modifs.size() > 0) {
-                    ModificationItem[] array;
-
-                    array = new ModificationItem[modifs.size()];
-                    modifs.copyInto(array);
+                if (!modifs.isEmpty()) {
+                    ModificationItem[] array = modifs.toArray(new ModificationItem[modifs.size()]);
                     _ctx.modifyAttributes(result.getName(), array);
                     notify(result.getName(), ImportEventListener.REFRESHED);
                 } else {

--- a/xml/src/main/java/org/exolab/castor/dsml/mozilla/MozillaEntryConsumer.java
+++ b/xml/src/main/java/org/exolab/castor/dsml/mozilla/MozillaEntryConsumer.java
@@ -144,7 +144,7 @@ class MozillaEntryConsumer
 	} else if ( tagName.equals( XML.Entries.Elements.ENTRY ) ) {
 	    if ( _attrSet == null || _attr != null )
 		throw new SAXException( Messages.format( "dsml.closingTagNotRecognized", tagName ) );
-	    _entries.addElement( new LDAPEntry( _entryDN, _attrSet ) );
+	    _entries.add( new LDAPEntry( _entryDN, _attrSet ) );
 	    _entryDN = null;
 	    _attrSet = null;
 	} else if ( tagName.equals( XML.Entries.Elements.OBJECT_CLASS ) ||

--- a/xml/src/main/java/org/exolab/castor/mapping/loader/AbstractMappingLoader.java
+++ b/xml/src/main/java/org/exolab/castor/mapping/loader/AbstractMappingLoader.java
@@ -231,7 +231,7 @@ public abstract class AbstractMappingLoader extends AbstractMappingLoader2 {
         
         // If there is configuration data, make sure that the field handler class
         // supports it.
-        if (params.size() > 0) {
+        if (!params.isEmpty()) {
             if (!ConfigurableFieldHandler.class.isAssignableFrom(fieldHandler.getClass())) {
                 throw new MappingException(Messages.format("mapping.classNotConfigurableFieldHandler", 
                         def.getName(), def.getClazz()));
@@ -862,11 +862,9 @@ public abstract class AbstractMappingLoader extends AbstractMappingLoader2 {
             // Convert method call sequence for nested fields to arrays
             Method[] getArray = null;
             Method[] setArray = null;
-            if (getSequence.size() > 0) {
-                getArray = new Method[getSequence.size()];
-                getArray = getSequence.toArray(getArray);
-                setArray = new Method[setSequence.size()];
-                setArray = setSequence.toArray(setArray);
+            if (!getSequence.isEmpty()) {
+                getArray = getSequence.toArray(new Method[getSequence.size()]);
+                setArray = setSequence.toArray(new Method[setSequence.size()]);
             }
 
             // Create handler
@@ -904,7 +902,7 @@ public abstract class AbstractMappingLoader extends AbstractMappingLoader2 {
                             fldMap.getGetMethod(), rtype, javaClass.getName());
                 }
 
-                if ((fldType == null) && (collectionType == null)) {
+                if (fldType == null && collectionType == null) {
                     fldType = getMethod.getReturnType();
                 }
             }

--- a/xml/src/main/java/org/exolab/castor/mapping/loader/AbstractMappingLoader2.java
+++ b/xml/src/main/java/org/exolab/castor/mapping/loader/AbstractMappingLoader2.java
@@ -24,12 +24,12 @@ public abstract class AbstractMappingLoader2 implements MappingLoader {
     /** 
      * All class descriptors in the original order. 
      */
-    private List<ClassDescriptor> _descriptors = new Vector<ClassDescriptor>();
+    private final List<ClassDescriptor> _descriptors = new Vector<>();
 
     /** 
      * All class descriptors added so far, keyed by class name. 
      */
-    private Map<String, ClassDescriptor> _descriptorsByClassname = 
+    private final Map<String, ClassDescriptor> _descriptorsByClassname = 
         new Hashtable<String, ClassDescriptor>();
 
     public AbstractMappingLoader2(final ClassLoader loader) {

--- a/xml/src/main/java/org/exolab/castor/mapping/loader/ClassDescriptorImpl.java
+++ b/xml/src/main/java/org/exolab/castor/mapping/loader/ClassDescriptorImpl.java
@@ -210,7 +210,7 @@ public class ClassDescriptorImpl implements ClassDescriptor {
      * @see java.lang.Object#toString()
      */
     public String toString() {
-        return _javaClass.getName() + "[" + _natures.toString() + "]";
+        return _javaClass.getName() + '[' + _natures + ']';
     }
 
     /**

--- a/xml/src/main/java/org/exolab/castor/mapping/loader/CollectionHandlers.java
+++ b/xml/src/main/java/org/exolab/castor/mapping/loader/CollectionHandlers.java
@@ -47,10 +47,11 @@ package org.exolab.castor.mapping.loader;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
-import java.util.Vector;
+import java.util.List;
 
 import org.castor.core.util.AbstractProperties;
 import org.castor.xml.XMLProperties;
@@ -76,7 +77,7 @@ public final class CollectionHandlers {
    private static boolean _loadedCollectionClass = false;
 
    static {
-      Vector<Info> allInfo = new Vector<Info>();
+      List<Info> allInfo = new ArrayList<>();
       AbstractProperties properties = XMLProperties.newInstance();
       StringTokenizer tokenizer = new StringTokenizer(properties.getString(
             XMLProperties.COLLECTION_HANDLERS_FOR_JAVA_11_OR_12, ""), ", ");
@@ -90,14 +91,13 @@ public final class CollectionHandlers {
             Method method = infoClass.getMethod("getCollectionHandlersInfo", (Class[]) null);
             Info[] info = (Info[]) method.invoke(null, (Object[]) null);
             for (int i = 0; i < info.length; ++i)
-               allInfo.addElement(info[i]);
+               allInfo.add(info[i]);
          } catch (Exception except) {
             // System.err.println( "CollectionHandlers: " + except.toString()
             // );
          }
       }
-      _info = new Info[allInfo.size()];
-      allInfo.copyInto(_info);
+      _info = allInfo.toArray(new Info[allInfo.size()]);
    }
 
    /**

--- a/xml/src/main/java/org/exolab/castor/mapping/loader/Types.java
+++ b/xml/src/main/java/org/exolab/castor/mapping/loader/Types.java
@@ -254,7 +254,7 @@ public class Types {
       return false;
    }
 
-   private static final Vector<Class<?>> ENUMS = new Vector<Class<?>>();
+   private static final Vector<Class<?>> ENUMS = new Vector<>();
 
    public static void addEnumType(Class<?> type) {
       ENUMS.add(type);
@@ -264,7 +264,7 @@ public class Types {
       return ENUMS.contains(type);
    }
 
-   private static final Vector<Class<?>> CONVERTIBLE = new Vector<Class<?>>();
+   private static final Vector<Class<?>> CONVERTIBLE = new Vector<>();
 
    public static void addConvertibleType(Class<?> type) {
       CONVERTIBLE.add(type);

--- a/xml/src/main/java/org/exolab/castor/util/CommandLineOptions.java
+++ b/xml/src/main/java/org/exolab/castor/util/CommandLineOptions.java
@@ -36,15 +36,9 @@ import org.castor.core.util.Messages;
  * @version $Revision$ $Date: 2006-04-10 16:39:24 -0600 (Mon, 10 Apr 2006) $
  */
 public class CommandLineOptions {
-    private Vector _flags = null;
-    private Hashtable _optionInfo = null;
-    private PrintWriter _errorWriter = null;
-    
-    public CommandLineOptions() {
-        _flags = new Vector();
-        _optionInfo = new Hashtable();
-        _errorWriter = new PrintWriter(System.out);
-    }
+    private final Vector<String> _flags = new Vector<>();
+    private final Hashtable<String, CmdLineOption> _optionInfo = new Hashtable<>();
+    private final PrintWriter _errorWriter = new PrintWriter(System.out);
     
     /**
      * Adds the flag to list of available command line options.
@@ -88,7 +82,7 @@ public class CommandLineOptions {
     public void addFlag(final String flag, final String usageText, final String comment,
             final boolean optional) {
         if (flag == null) { return; }
-        _flags.addElement(flag);
+        _flags.add(flag);
         
         CmdLineOption opt = new CmdLineOption(flag);
         opt.setComment(comment);
@@ -212,13 +206,12 @@ public class CommandLineOptions {
         printUsage(pw);
         pw.println();
         
-        if (_flags.size() > 0) {
+        if (!_flags.isEmpty()) {
             pw.println("Flag               Description");
             pw.println("----------------------------------------------");
         }
-        for (int i = 0; i < _flags.size(); i++) {
-            String flag = (String) _flags.elementAt(i);
-            CmdLineOption opt = (CmdLineOption) _optionInfo.get(flag);
+        for (String flag : _flags) {
+            CmdLineOption opt = _optionInfo.get(flag);
             
             pw.print('-');
             pw.print(flag);
@@ -250,7 +243,7 @@ class CmdLineOption {
     private boolean _optional = false;
     private String _usageText = null;
     private String _comment = null;
-    private String _flag = null;
+    private final String _flag;
     
     /**
      * Creates a new CmdLineOption.

--- a/xml/src/main/java/org/exolab/castor/util/dialog/ConsoleDialog.java
+++ b/xml/src/main/java/org/exolab/castor/util/dialog/ConsoleDialog.java
@@ -196,8 +196,8 @@ public class ConsoleDialog implements Dialog {
      * @return each character separated by a pipe and in parenthesis
      */
     private String makeList(final String values) {
-        StringBuilder sb = new StringBuilder(values.length() * 2);
-        sb.append('(');
+        StringBuilder sb = new StringBuilder(values.length() * 2)
+            .append('(');
         for (int i = 0; i < values.length(); i++) {
             sb.append(values.charAt(i)).append('|');
         }
@@ -216,7 +216,7 @@ public class ConsoleDialog implements Dialog {
     private String listInput(final String values) {
         StringBuilder sb = new StringBuilder(values.length() * 4);
         for (int i = 0; i < values.length(); i++) {
-            sb.append('\'') .append(values.charAt(i)) .append("', ");
+            sb.append('\'').append(values.charAt(i)).append("', ");
         }
         sb.append("or '?'");
         return sb.toString();

--- a/xml/src/main/java/org/exolab/castor/xml/Introspector.java
+++ b/xml/src/main/java/org/exolab/castor/xml/Introspector.java
@@ -254,7 +254,7 @@ public final class Introspector implements PropertyChangeListener {
         if (_handlerFactoryList == null) {
             _handlerFactoryList = new Vector<>();
         }
-        _handlerFactoryList.addElement(factory);
+        _handlerFactoryList.add(factory);
         registerHandlerFactory(factory);
     } //-- addFieldHandlerFactory
 
@@ -863,7 +863,7 @@ public final class Introspector implements PropertyChangeListener {
         //-- if list is null, just return
         if (_handlerFactoryList == null) return false;
 
-        if (_handlerFactoryList.removeElement(factory)) {
+        if (_handlerFactoryList.remove(factory)) {
             //-- re-register remaining handlers
             _handlerFactoryMap.clear();
             for (FieldHandlerFactory tmp : _handlerFactoryList) {
@@ -1245,12 +1245,12 @@ public final class Introspector implements PropertyChangeListener {
     private static Class[] loadCollections() {
 
 
-        Vector<Class> collections = new Vector<>(6);
+        List<Class> collections = new ArrayList<>(6);
 
         //-- JDK 1.1
-        collections.addElement(Vector.class);
-        collections.addElement(Enumeration.class);
-        collections.addElement(Hashtable.class);
+        collections.add(Vector.class);
+        collections.add(Enumeration.class);
+        collections.add(Hashtable.class);
 
         //-- JDK 1.2+
         ClassLoader loader = Vector.class.getClassLoader();
@@ -1271,7 +1271,7 @@ public final class Introspector implements PropertyChangeListener {
         if (clazz != null) {
             //-- java.util.List found, add to collections,
             //-- also add java.util.Map
-            collections.addElement(clazz);
+            collections.add(clazz);
 
             clazz = null;
             try {
@@ -1281,7 +1281,7 @@ public final class Introspector implements PropertyChangeListener {
                 }
                 else clazz = Class.forName(MAP);
                 if (clazz != null) {
-                    collections.addElement(clazz);
+                    collections.add(clazz);
                 }
                 //-- java.util.Set
                 if (loader != null) {
@@ -1289,7 +1289,7 @@ public final class Introspector implements PropertyChangeListener {
                 }
                 else clazz = Class.forName(SET_COLLECTION);
                 if (clazz != null) {
-                    collections.addElement(clazz);
+                    collections.add(clazz);
                 }
 
 
@@ -1300,11 +1300,7 @@ public final class Introspector implements PropertyChangeListener {
             }
         }
 
-
-        Class[] classes = new Class[collections.size()];
-        collections.copyInto(classes);
-
-        return classes;
+        return collections.toArray(new Class[collections.size()]);
     } //-- loadCollections
 
 

--- a/xml/src/main/java/org/exolab/castor/xml/Marshaller.java
+++ b/xml/src/main/java/org/exolab/castor/xml/Marshaller.java
@@ -1084,7 +1084,7 @@ public class Marshaller extends MarshalFramework {
         if (!isNil) {
             cls = object.getClass();
             
-            if (_proxyInterfaces.size() > 0) {
+            if (!_proxyInterfaces.isEmpty()) {
                 boolean isProxy = false;
                 
                 Class<?>[] interfaces = cls.getInterfaces();

--- a/xml/src/main/java/org/exolab/castor/xml/NamespacesStack.java
+++ b/xml/src/main/java/org/exolab/castor/xml/NamespacesStack.java
@@ -182,7 +182,7 @@ public class NamespacesStack {
     */
    public void removeNamespaceScope() {
       // removes the current namespace
-      if (namespaceStack.size() > 0) {
+      if (!namespaceStack.isEmpty()) {
          namespaceStack.remove(namespaceStack.size() - 1);
       } else {
          this.logger.error("Trying to remove a namespaces scope from an empty stack of Namespaces");
@@ -195,7 +195,7 @@ public class NamespacesStack {
     * @return the current namespace scope.
     */
    public Namespaces getCurrentNamespaceScope() {
-      if (namespaceStack.size() == 0) {
+      if (namespaceStack.isEmpty()) {
          addNewNamespaceScope();
       }
       return namespaceStack.get(namespaceStack.size() - 1);

--- a/xml/src/main/java/org/exolab/castor/xml/StartElementProcessor.java
+++ b/xml/src/main/java/org/exolab/castor/xml/StartElementProcessor.java
@@ -666,7 +666,7 @@ public class StartElementProcessor {
                     state.setClassDescriptor(classDesc);
                     Arguments args = _unmarshalHandler.processConstructorArgs(
                             atts, classDesc);
-                    if ((args != null) && (args.size() > 0)) {
+                    if (args != null && args.size() > 0) {
                         state.setConstructorArguments(args);
                     }
                 }

--- a/xml/src/main/java/org/exolab/castor/xml/Validator.java
+++ b/xml/src/main/java/org/exolab/castor/xml/Validator.java
@@ -187,7 +187,7 @@ public class Validator implements ClassValidator {
     }
     
     public void checkUnresolvedIdrefs(ValidationContext context) throws ValidationException {
-        if (context.getUnresolvedIdRefs().size() > 0) {
+        if (!context.getUnresolvedIdRefs().isEmpty()) {
             String err = MessageFormat.format(resourceBundle.getString("validator.error.class.descriptor.resolver.null"), new Object[] {context.getUnresolvedIdRefs().toString()});
             throw new ValidationException(err);
         }

--- a/xml/src/main/java/org/exolab/castor/xml/XMLMappingLoader.java
+++ b/xml/src/main/java/org/exolab/castor/xml/XMLMappingLoader.java
@@ -233,8 +233,8 @@ public final class XMLMappingLoader extends AbstractMappingLoader {
             checkFieldNameDuplicates(allFields, javaClass);
             
             // Identify identity and normal fields. Note that order must be preserved.
-            List fieldList = new ArrayList(allFields.length);
-            List idList = new ArrayList();
+            List<FieldDescriptorImpl> fieldList = new ArrayList<>(allFields.length);
+            List<FieldDescriptor> idList = new ArrayList<>();
             if (extDesc == null) {
                 // Sort fields into 2 lists based on identity definition of field.
                 for (int i = 0; i < allFields.length; i++) {
@@ -245,14 +245,13 @@ public final class XMLMappingLoader extends AbstractMappingLoader {
                     }
                 }
                 
-                if (idList.size() == 0) {
+                if (idList.isEmpty()) {
                     // Found no identities based on identity definition of field.
                     // Try to find identities based on identity definition on class.
                     String[] idNames = classMapping.getIdentity();
                     
-                    FieldDescriptor identity;
                     for (int i = 0; i < idNames.length; i++) {
-                        identity = findIdentityByName(fieldList, idNames[i], javaClass);
+                        FieldDescriptor identity = findIdentityByName(fieldList, idNames[i], javaClass);
                         if (identity != null) {
                             idList.add(identity);
                         } else {
@@ -269,20 +268,18 @@ public final class XMLMappingLoader extends AbstractMappingLoader {
                 if (extDesc.getIdentity() != null) { idList.add(extDesc.getIdentity()); }
                 
                 // Search redefined identities in extending class.
-                FieldDescriptor identity;
                 for (int i = 0; i < idList.size(); i++) {
-                    String idname = ((FieldDescriptor) idList.get(i)).getFieldName();
-                    identity = findIdentityByName(fieldList, idname, javaClass);
+                    String idname = idList.get(i).getFieldName();
+                    FieldDescriptor identity = findIdentityByName(fieldList, idname, javaClass);
                     if (identity != null) { idList.set(i, identity); }
                 }
             }
             
             FieldDescriptor xmlId = null;
-            if (idList.size() != 0) { xmlId = (FieldDescriptor) idList.get(0); }
+            if (!idList.isEmpty()) { xmlId = (FieldDescriptor) idList.get(0); }
             
             if (xmlId != null) { xmlClassDesc.setIdentity((XMLFieldDescriptorImpl) xmlId); }
-            for (int i = 0; i < fieldList.size(); i++) {
-                FieldDescriptor fieldDesc = (FieldDescriptor) fieldList.get(i);
+            for (FieldDescriptor fieldDesc : fieldList) {
                 if (fieldDesc != null) {
                     xmlClassDesc.addFieldDescriptor((XMLFieldDescriptorImpl) fieldDesc);
                 }

--- a/xml/src/main/java/org/exolab/castor/xml/handlers/DateFieldHandler.java
+++ b/xml/src/main/java/org/exolab/castor/xml/handlers/DateFieldHandler.java
@@ -40,12 +40,13 @@ package org.exolab.castor.xml.handlers;
 import java.lang.reflect.Array;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.TimeZone;
-import java.util.Vector;
 
 import org.exolab.castor.mapping.FieldHandler;
 import org.exolab.castor.types.DateTime;
@@ -134,13 +135,11 @@ public class DateFieldHandler extends XMLFieldHandler {
             formatted = values;
         } else if (java.util.Enumeration.class.isAssignableFrom(type)) {
             Enumeration enumeration = (Enumeration) val;
-            Vector values = new Vector();
+            List<String> values = new ArrayList<>();
             while (enumeration.hasMoreElements()) {
-                values.addElement(format(enumeration.nextElement()));
+                values.add(format(enumeration.nextElement()));
             }
-            String[] valuesArray = new String[values.size()];
-            values.copyInto(valuesArray);
-            formatted = valuesArray;
+            formatted = values.toArray(new String[values.size()]);
         } else {
             formatted = val.toString();
         }

--- a/xml/src/main/java/org/exolab/castor/xml/location/XPathLocation.java
+++ b/xml/src/main/java/org/exolab/castor/xml/location/XPathLocation.java
@@ -81,7 +81,7 @@ public class XPathLocation implements Location, java.io.Serializable {
     public void addAttribute(final String name) {
         if (_allowChildrenOrAtts) {
             _allowChildrenOrAtts = false;
-            _path.addElement("@" + name);
+            _path.add("@" + name);
         }
     }
 
@@ -91,7 +91,7 @@ public class XPathLocation implements Location, java.io.Serializable {
      */
     public void addChild(final String name) {
         if (_allowChildrenOrAtts) {
-            _path.addElement(name);
+            _path.add(name);
         }
     }
 

--- a/xml/src/main/java/org/exolab/castor/xml/util/SAX2DOMHandler.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/SAX2DOMHandler.java
@@ -62,9 +62,9 @@ import java.util.Stack;
  */
 public class SAX2DOMHandler extends HandlerBase {
     
-    private Node _node;
+    private final Node _node;
     
-    private Stack<Element> _parents = new Stack<Element>();
+    private final Stack<Element> _parents = new Stack<Element>();
 
     /**
      * Creates new instance of {@link SAX2DOMHandler} class.
@@ -77,7 +77,7 @@ public class SAX2DOMHandler extends HandlerBase {
 
     @Override
     public void startElement(final String name, final AttributeList attributes) {
-        Node parent = _parents.size() > 0 ? (Node) _parents.peek() : _node;
+        Node parent = !_parents.isEmpty() ? _parents.peek() : _node;
         final Document document = getDocument(parent);
 
         Element element = document.createElement(name);
@@ -92,7 +92,7 @@ public class SAX2DOMHandler extends HandlerBase {
     @Override
     public void characters(final char[] chars, final int offset, final int length) {
         String data = new String(chars, offset, length);
-        Node parent = (_parents.size() > 0) ? (Node) _parents.peek() : _node;
+        Node parent = !_parents.isEmpty() ? _parents.peek() : _node;
         Node last = parent.getLastChild();
         if ((last != null) && (last.getNodeType() == Node.TEXT_NODE)) {
             ((Text) last).appendData(data);

--- a/xml/src/main/java/org/exolab/castor/xml/util/XMLClassDescriptorImpl.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/XMLClassDescriptorImpl.java
@@ -159,15 +159,15 @@ public class XMLClassDescriptorImpl extends Validator implements XMLClassDescrip
     
     /** Defines the sequence of elements for unmarshalling validation
      *  (to be used with compositor == SEQUENCE only). */
-    private List<XMLFieldDescriptor> _sequenceOfElements = new ArrayList<XMLFieldDescriptor>();
+    private final List<XMLFieldDescriptor> _sequenceOfElements = new ArrayList<XMLFieldDescriptor>();
     
-    private List<String> _substitutes = new LinkedList<String>();    
+    private List<String> _substitutes = new LinkedList<String>();
 
     /** Map holding the properties set and read by Natures. */
-    private Map<String, Object> _properties = new HashMap<String, Object>();
+    private final Map<String, Object> _properties = new HashMap<String, Object>();
     
     /** Map holding the available natures. */
-    private Set<String> _natures = new HashSet<String>();
+    private final Set<String> _natures = new HashSet<String>();
 
     /**
      * Creates an XMLClassDescriptor class used by the Marshalling Framework.
@@ -286,7 +286,7 @@ public class XMLClassDescriptorImpl extends Validator implements XMLClassDescrip
      */
     public void checkDescriptorForCorrectOrderWithinSequence(
             final XMLFieldDescriptor elementDescriptor, UnmarshalState parentState, String xmlName) throws ValidationException {
-        if (_compositor == SEQUENCE && _sequenceOfElements.size() > 0) {
+        if (_compositor == SEQUENCE && !_sequenceOfElements.isEmpty()) {
         	
         	if (parentState.getExpectedIndex() == _sequenceOfElements.size() ) {
         		throw new ValidationException ("Element with name " + xmlName + " passed to type " + getXMLName() + " in incorrect order; It is not allowed to be the last element of this sequence!");

--- a/xml/src/main/java/org/exolab/castor/xml/util/XMLClassDescriptorResolverImpl.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/XMLClassDescriptorResolverImpl.java
@@ -303,7 +303,7 @@ public class XMLClassDescriptorResolverImpl implements XMLClassDescriptorResolve
         // @TODO Joachim 2007-05-05 the class loader is NOT used!
         // get a list of all descriptors with the correct xmlName, regardless of their namespace
         List<ClassDescriptor> possibleMatches = _descriptorCache.getDescriptors(xmlName);
-        if (possibleMatches.size() == 0) {
+        if (possibleMatches.isEmpty()) {
             // nothing matches that XML name
             return null;
         }

--- a/xmlctf-framework/src/main/java/org/castor/xmlctf/compiler/OracleJavaCompiler.java
+++ b/xmlctf-framework/src/main/java/org/castor/xmlctf/compiler/OracleJavaCompiler.java
@@ -97,7 +97,7 @@ public class OracleJavaCompiler implements Compiler {
 	 */
 	public void compileDirectory() {
 		List<File> filesList = findSourceFiles(_baseDirectory);
-		if (filesList.size() > 0) {
+		if (!filesList.isEmpty()) {
 			// filesList.addAll(0, getCompileArguments(_baseDirectory,
 			// _outputDirectory));
 

--- a/xmlctf/src/test/java/org/castor/xmlctf/bestpractise/genpackage/PartialTermination.java
+++ b/xmlctf/src/test/java/org/castor/xmlctf/bestpractise/genpackage/PartialTermination.java
@@ -74,7 +74,7 @@ public class PartialTermination implements java.io.Serializable {
     public void addAssignmentNotification(
             final org.castor.xmlctf.bestpractise.genpackage.AssignmentNotification vAssignmentNotification)
     throws java.lang.IndexOutOfBoundsException {
-        this._assignmentNotificationList.addElement(vAssignmentNotification);
+        this._assignmentNotificationList.add(vAssignmentNotification);
     }
 
     /**

--- a/xmlctf/src/test/java/org/castor/xmlctf/bestpractise/genpackage/UnderlyerAdjustment.java
+++ b/xmlctf/src/test/java/org/castor/xmlctf/bestpractise/genpackage/UnderlyerAdjustment.java
@@ -56,7 +56,7 @@ implements java.io.Serializable
     public void addUnwindCashflow(
             final org.castor.xmlctf.bestpractise.genpackage.UnwindCashflow vUnwindCashflow)
     throws java.lang.IndexOutOfBoundsException {
-        this._unwindCashflowList.addElement(vUnwindCashflow);
+        this._unwindCashflowList.add(vUnwindCashflow);
     }
 
     /**


### PR DESCRIPTION
* Added `final` declarations to member variables, when applicable.
* Replaced `addElement` and `removeElement` (`Vector`) with `add` and `remove` (`Collection`).
* Replaced `Vector.copyInto` with `Collection.toArray`.
* Replaced some old index iteration with *enhanced for loops*.
* Replaced local `Vector` variable with `ArrayList` since synchronization overhead is not necessary.
* Removed some redundant parentheses and redundant casting.
* Leveraged the `Collections.emptyEnumeration` singleton to avoid creating an empty collection.
* Removed some redundant calls to `toString`.
* Replaced `StringBuffer` with `StringBuilder`, and leveraged chaining more.