### PR TITLE
Collections of type Set or SortedSet generate code that does not compile

### DIFF
--- a/codegen/src/main/java/org/exolab/castor/builder/factory/CollectionJ2NoIndexMemberAndAccessorFactory.java
+++ b/codegen/src/main/java/org/exolab/castor/builder/factory/CollectionJ2NoIndexMemberAndAccessorFactory.java
@@ -29,7 +29,7 @@ public class CollectionJ2NoIndexMemberAndAccessorFactory
   /**
    * {@inheritDoc} supresses the method creation
    */
-  protected void createGetByIndexMethod(final CollectionInfo fieldInfo, final JClass jClass) {
+  protected void createGetByIndexMethod(final CollectionInfo fieldInfo, final JClass jClass, boolean useJava50) {
     // do not create such method
   }
 


### PR DESCRIPTION
resolves #47 
useJava50 boolean parameter was added to createGetByIndexMethod(...) in CollectionMemberAndAccessorFactory but it was not added to overridden method in CollectionJ2NoIndexMemberAndAccessorFactory