### PR TITLE
Generated code shows wrong castor version in comments

### DIFF
--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -29,6 +29,13 @@
             <resource>
                 <directory>src/main/resources</directory>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            	<filtering>true</filtering>
+            	<includes>
+            		<include>META-INF/MANIFEST.MF</include>
+            	</includes>
+            </resource>
             <!-- 
             <resource>
                 <directory>src/main/resources</directory>

--- a/xml/src/main/java/org/exolab/castor/util/Version.java
+++ b/xml/src/main/java/org/exolab/castor/util/Version.java
@@ -57,12 +57,12 @@ public final class Version {
   /**
    * The version number
    */
-  public static final String VERSION = "1.3.3";
+  public static final String VERSION = Version.class.getPackage().getImplementationVersion();
 
   /**
    * The version date.
    */
-  public static final String VERSION_DATE = "20131231";
+  public static final String VERSION_DATE = "20131231"; // Who updates this?
 
   /**
    * The version number with build information


### PR DESCRIPTION
```java
/*
 * This class was automatically generated with
 * <a href="http://www.castor.org">Castor 1.3.3</a>, using an XML
 * Schema.
 * $Id$
 */
```
This was generated from Castor 1.4.1-SNAPSHOT from GitHub even though it says 1.3.3 in the generated comment.  Looks like `xml/src/main/java/org/exolab/castor/util/Version.java` has not been manually updated to reflect the current Castor version.

These changes modify the maven build so filtering is performed on `xml/src/main/resources/META-INF/MANIFEST.MF` (to set the correct version number) and Version.java is updated to set the static VERSION field to the value read from the MANIFEST.MF file (should happen once at class load time)