### PR TITLE
Performance fixes

### DIFF
--- a/xml/src/main/java/org/castor/mapping/MappingUnmarshaller.java
+++ b/xml/src/main/java/org/castor/mapping/MappingUnmarshaller.java
@@ -102,6 +102,16 @@ public final class MappingUnmarshaller {
 
     _internalContext = internalContext;
   }
+  
+  /**
+	 * This API is created to use the existing XMLContext object instead of creating a new one.
+	 * @param internalContext
+	 */
+	public MappingUnmarshaller(InternalContext internalContext) {
+		_registry = new MappingLoaderRegistry(new CoreProperties());
+		_idResolver = new MappingUnmarshallIDResolver();
+		_internalContext = internalContext;
+	}
 
   /**
    * Enables or disables the ability to allow the redefinition of class mappings.

--- a/xml/src/main/java/org/exolab/castor/xml/CastorThreadLocal.java
+++ b/xml/src/main/java/org/exolab/castor/xml/CastorThreadLocal.java
@@ -1,0 +1,52 @@
+/**
+ * This class is created to support ThreadLocal in Castor. This class is introduced to support
+ * different xml document requests SOAP/JMS etc. having the same xml name as root element. If xml names are same with
+ * different incoming xml requests causes issues with Castor when Castor caching is used as Castor only expecting
+ * one-to-one mapping between Xml element and corresponding ComplexType. The required context is set by the application
+ * as required to set in the ThreadLocal.
+ * mappingInfo.put("class", "com.org.Customer");
+ * mappingInfo.put("map-to", "cust");
+ * mappingInfo.put("class", "com.org.SpecialCustomer");
+ * mappingInfo.put("map-to", "cust");
+ *
+ */
+package org.exolab.castor.xml;
+
+import java.util.WeakHashMap;
+
+/**
+ * This class provides thread-local variables. These
+ * variables differ from their normal counterparts in that each thread that
+ * accesses one (via its get or set method) has its own, independently
+ * initialised copy of the variable.
+ * 
+ */
+public class CastorThreadLocal {
+	private static ThreadLocal<WeakHashMap<String, Object>> threadLocal = new ThreadLocal<WeakHashMap<String, Object>>();
+	private static final String REQ_CONTEXT = "REQ_CONTEXT";
+
+	private static WeakHashMap<String, Object> getDetailsMap() {
+		WeakHashMap<String, Object> detailsMap = threadLocal.get();
+		if (detailsMap == null) {
+			detailsMap = new WeakHashMap<String, Object>();
+			threadLocal.set(detailsMap);
+		}
+		return detailsMap;
+	}
+
+	/**
+	 * This request Context is MF ID. Appending this to the xml element will make the element
+	 * unique across web services calls.
+	 * @return
+	 */
+	public static String getReqContext() {
+		if (getDetailsMap().get(REQ_CONTEXT) != null) {
+			return (String) getDetailsMap().get(REQ_CONTEXT);
+		}
+		return null;
+	}
+
+	public static void setReqContext(String reqContext) {
+		getDetailsMap().put(REQ_CONTEXT, reqContext);
+	}
+}

--- a/xml/src/main/java/org/exolab/castor/xml/XMLContext.java
+++ b/xml/src/main/java/org/exolab/castor/xml/XMLContext.java
@@ -70,17 +70,18 @@ public class XMLContext {
   }
 
   /**
-   * Instructs Castor to load class descriptors from the mapping given.
-   * 
+   * Instructs Castor to load class descriptors from the mapping given. Here the same _internalContext
+   * object is passed to MappingUnmarshaller so that it makes use of the same descriptor caching of the
+   * _internalContext object.
    * @param mapping Castor XML mapping (file), from which the required class descriptors will be
    *        derived.
    * @throws MappingException If the {@link Mapping} cannot be loaded and analyzed successfully.
    */
   public void addMapping(final Mapping mapping) throws MappingException {
-    MappingUnmarshaller mappingUnmarshaller = new MappingUnmarshaller();
-    MappingLoader mappingLoader = mappingUnmarshaller.getMappingLoader(mapping, BindingType.XML);
-    _internalContext.getXMLClassDescriptorResolver().setMappingLoader(mappingLoader);
-  }
+		MappingUnmarshaller mappingUnmarshaller = new MappingUnmarshaller(_internalContext);
+		MappingLoader mappingLoader = mappingUnmarshaller.getMappingLoader(mapping, BindingType.XML);
+		_internalContext.getXMLClassDescriptorResolver().setMappingLoader(mappingLoader);
+	}
 
   /**
    * Loads the class descriptor for the class instance specified. The use of this method is useful
@@ -287,4 +288,10 @@ public class XMLContext {
   public void setClassLoader(ClassLoader classLoader) {
     this._internalContext.setClassLoader(classLoader);
   }
+  /**
+  * This is called by the application to set the right context.
+  */
+  public void setReqContext(String requestContext) {
+		CastorThreadLocal.setReqContext(requestContext);
+	}
 }

--- a/xml/src/main/java/org/exolab/castor/xml/util/resolvers/ByDescriptorClass.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/resolvers/ByDescriptorClass.java
@@ -56,19 +56,25 @@ public class ByDescriptorClass extends AbstractResolverClassCommand {
       return results;
     }
 
-    StringBuilder descriptorClassName = new StringBuilder(className);
-    descriptorClassName.append(XMLConstants.DESCRIPTOR_SUFFIX);
-    Class descriptorClass = ResolveHelpers.loadClass(classLoader, descriptorClassName.toString());
-
-    // If we didn't find the descriptor, look in descriptor package
-    if (descriptorClass == null) {
-      int offset = descriptorClassName.lastIndexOf(".");
-      if (offset != -1) {
-        descriptorClassName.insert(offset, ".");
-        descriptorClassName.insert(offset + 1, XMLConstants.DESCRIPTOR_PACKAGE);
-        descriptorClass = ResolveHelpers.loadClass(classLoader, descriptorClassName.toString());
-      }
-    }
+	Class descriptorClass = null;
+	StringBuilder descriptorClassName = new StringBuilder(className);
+	descriptorClassName.append(XMLConstants.DESCRIPTOR_SUFFIX);
+	// Try to load the below pattern first as it avoids searching for a descriptors which really does not exist which will help avoiding thread blocks on the //classloader for a wrong file pattern.
+	int offset = descriptorClassName.lastIndexOf(".");
+	if (offset != -1) {
+		descriptorClassName.insert(offset , ".");
+		descriptorClassName.insert(offset + 1, XMLConstants.DESCRIPTOR_PACKAGE);
+		descriptorClass = ResolveHelpers.loadClass(
+				classLoader, descriptorClassName.toString());
+	}
+	
+	// Try with Castor default pattern.
+	if (descriptorClass == null) {
+		StringBuilder defaultDescriptorClassName = new StringBuilder(className);
+		defaultDescriptorClassName.append(XMLConstants.DESCRIPTOR_SUFFIX);
+		 descriptorClass = ResolveHelpers.loadClass(
+				classLoader, defaultDescriptorClassName.toString());
+	}
 
     if (descriptorClass != null) {
       try {

--- a/xml/src/main/java/org/exolab/castor/xml/util/resolvers/CastorXMLStrategy.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/resolvers/CastorXMLStrategy.java
@@ -119,13 +119,17 @@ public class CastorXMLStrategy implements ResolverStrategy {
       return descriptor;
     }
 
-    this.resolvePackage(resolverResults, packageName);
+    /**
+	* if any of the Descriptor entry mapping is missing , It tries to load the whole CDR file and creates
+	* happens on for that .cdr file which comes first in the class path.
+	*/
+	resolverResults.addAllDescriptors(new ByDescriptorClass().resolve(className, _properties));
     descriptor = resolverResults.getDescriptor(className);
     if (descriptor != null) {
       return descriptor;
     }
 
-    resolverResults.addAllDescriptors(new ByDescriptorClass().resolve(className, _properties));
+    this.resolvePackage(resolverResults, packageName);
     descriptor = resolverResults.getDescriptor(className);
     if (descriptor != null) {
       return descriptor;

--- a/xml/src/main/java/org/exolab/castor/xml/util/resolvers/CastorXMLStrategy.java
+++ b/xml/src/main/java/org/exolab/castor/xml/util/resolvers/CastorXMLStrategy.java
@@ -120,7 +120,11 @@ public class CastorXMLStrategy implements ResolverStrategy {
     }
 
     /**
+	* Moving the search BYCDR later. First load by ByDescriptorClass using the right pattern. The issue with searching with CDR is,
 	* if any of the Descriptor entry mapping is missing , It tries to load the whole CDR file and creates
+	* the instances of all the descriptors again and add it to cache , in caching as we check with .contais
+	* which fails as its a new instance of descriptors so it add it again and causes the memory leak.
+	* The issue is more observed when the .CDR files are maintained as part of different jars and loading
 	* happens on for that .cdr file which comes first in the class path.
 	*/
 	resolverResults.addAllDescriptors(new ByDescriptorClass().resolve(className, _properties));


### PR DESCRIPTION
The main intention of these fixes:
1. Use single xmlcontext object to use descriptor caching properly.
2.Avoid checking .contains for descriptors while putting into the cache as it casues memory leaks if  .cdr files are not proper e.g. in different jars but in the same name space but with different entries.
3. Search with the right pattern of the descriptors in the first go to avoid thread blocks on the class loader.