### PR TITLE
Update spring.version to address security threats

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -729,7 +729,7 @@
    </pluginRepositories>
 
    <properties>
-      <spring.version>4.3.0.RELEASE</spring.version>
+      <spring.version>5.0.7.RELEASE</spring.version>
       <surefire.print.summary>false</surefire.print.summary>
       <VERSION>${project.version}</VERSION>
       <RELEASE />


### PR DESCRIPTION
Update spring.version from 4.3.0.RELEASE to 5.0.7.RELEASE to address multiple security threats, as detailed in:
castor-data-binding/castor/issues/74